### PR TITLE
Recover stranded link-preview/media commits + v1.2.0 version bump

### DIFF
--- a/bot-gateway/package.json
+++ b/bot-gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harmony/bot-gateway",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Harmony Bot API Gateway - WebSocket and REST API for bots",
   "type": "module",
   "main": "dist/index.js",

--- a/bot-gateway/src/api/BotRestAPI.ts
+++ b/bot-gateway/src/api/BotRestAPI.ts
@@ -243,17 +243,33 @@ export class BotRestAPI {
     }
   }
 
-  /** Ask the federation backend to enrich a message's link previews. Best-effort. */
+  /**
+   * Ask the federation backend to enrich a message's link previews.
+   * Best-effort. Auth: INTERNAL_API_SECRET when configured (scoped secret,
+   * preferred), otherwise the service-role key. Only send either over
+   * localhost or HTTPS - never a plain-http remote URL.
+   */
   private triggerLinkPreviewEnrichment(messageId: string): void {
     const federationUrl = process.env.FEDERATION_BACKEND_URL || 'http://localhost:3001'
-    const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY
-    if (!serviceKey) return
+    const secret = process.env.INTERNAL_API_SECRET || process.env.SUPABASE_SERVICE_ROLE_KEY
+    if (!secret) return
+
+    try {
+      const parsed = new URL(federationUrl)
+      const isLocal = parsed.hostname === 'localhost' || parsed.hostname === '127.0.0.1'
+      if (parsed.protocol !== 'https:' && !isLocal) {
+        console.warn('Refusing to send internal secret over plain http to a remote FEDERATION_BACKEND_URL')
+        return
+      }
+    } catch {
+      return
+    }
 
     fetch(`${federationUrl}/link-preview/enrich-message`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        Authorization: `Bearer ${serviceKey}`,
+        Authorization: `Bearer ${secret}`,
       },
       body: JSON.stringify({ messageId }),
     }).catch((err) => {

--- a/bot-gateway/src/api/BotRestAPI.ts
+++ b/bot-gateway/src/api/BotRestAPI.ts
@@ -233,12 +233,32 @@ export class BotRestAPI {
       
       // Log action
       await this.logBotAction(botId, 'message_sent', { channel_id: channelId, message_id: message.id })
-      
+
+      this.triggerLinkPreviewEnrichment(message.id)
+
       res.status(201).json(this.formatMessage(message))
     } catch (error: any) {
       console.error('Send message error:', error)
       res.status(500).json({ error: error.message || 'Internal server error' })
     }
+  }
+
+  /** Ask the federation backend to enrich a message's link previews. Best-effort. */
+  private triggerLinkPreviewEnrichment(messageId: string): void {
+    const federationUrl = process.env.FEDERATION_BACKEND_URL || 'http://localhost:3001'
+    const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+    if (!serviceKey) return
+
+    fetch(`${federationUrl}/link-preview/enrich-message`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${serviceKey}`,
+      },
+      body: JSON.stringify({ messageId }),
+    }).catch((err) => {
+      console.warn(`Link preview enrichment trigger failed for ${messageId}:`, err?.message || err)
+    })
   }
   
   private async lookupMessageByDiscordId(req: BotRequest, res: Response) {

--- a/federation-backend/package.json
+++ b/federation-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "harmony-federation-backend",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Harmony federated social platform - ActivityPub Federation Backend (FEDERATION ONLY)",
   "main": "dist/index.js",
   "type": "module",

--- a/federation-backend/src/routes/linkPreview.ts
+++ b/federation-backend/src/routes/linkPreview.ts
@@ -1,10 +1,25 @@
 import { Router } from 'express';
+import { timingSafeEqual } from 'node:crypto';
 import { fetchLinkPreview } from '../services/LinkPreviewService.js';
 import { getSupabaseClient, getSupabaseClientWithAuth } from '../config/supabase.js';
 import config from '../config/index.js';
 import { logger } from '../utils/logger.js';
 
 const router = Router();
+
+/**
+ * Constant-time secret comparison for the internal enrich endpoint.
+ * Prefer a dedicated INTERNAL_API_SECRET (scoped: leaking it only allows
+ * triggering link enrichment); fall back to the service-role key so
+ * zero-config deployments keep working.
+ */
+function isInternalCallerAuthorized(token: string): boolean {
+  const expected = process.env.INTERNAL_API_SECRET || config.SUPABASE_SERVICE_ROLE_KEY;
+  if (!token || !expected) return false;
+  const a = Buffer.from(token);
+  const b = Buffer.from(expected);
+  return a.length === b.length && timingSafeEqual(a, b);
+}
 
 /**
  * Internal service-to-service trigger: enrich one stored message's link
@@ -16,7 +31,7 @@ const router = Router();
 router.post('/enrich-message', async (req, res) => {
   const authHeader = req.headers.authorization;
   const token = authHeader?.startsWith('Bearer ') ? authHeader.substring(7) : '';
-  if (!token || token !== config.SUPABASE_SERVICE_ROLE_KEY) {
+  if (!isInternalCallerAuthorized(token)) {
     return res.status(401).json({ error: 'Unauthorized' });
   }
 

--- a/federation-backend/src/routes/linkPreview.ts
+++ b/federation-backend/src/routes/linkPreview.ts
@@ -1,8 +1,50 @@
 import { Router } from 'express';
 import { fetchLinkPreview } from '../services/LinkPreviewService.js';
-import { getSupabaseClientWithAuth } from '../config/supabase.js';
+import { getSupabaseClient, getSupabaseClientWithAuth } from '../config/supabase.js';
+import config from '../config/index.js';
+import { logger } from '../utils/logger.js';
 
 const router = Router();
+
+/**
+ * Internal service-to-service trigger: enrich one stored message's link
+ * previews immediately. Called by the bot-gateway right after inserting a
+ * bridged message, so its previews don't depend on the federation sweep /
+ * realtime subscription picking the row up.
+ * Auth: caller must present the service-role key (the bot-gateway has it).
+ */
+router.post('/enrich-message', async (req, res) => {
+  const authHeader = req.headers.authorization;
+  const token = authHeader?.startsWith('Bearer ') ? authHeader.substring(7) : '';
+  if (!token || token !== config.SUPABASE_SERVICE_ROLE_KEY) {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
+
+  const { messageId } = req.body || {};
+  if (!messageId || typeof messageId !== 'string') {
+    return res.status(400).json({ error: 'messageId is required' });
+  }
+
+  try {
+    const supabase = getSupabaseClient();
+    const { data: message } = await supabase
+      .from('messages')
+      .select('*')
+      .eq('id', messageId)
+      .single();
+
+    if (!message) {
+      return res.status(404).json({ error: 'Message not found' });
+    }
+
+    const { enrichMessageLinkPreviews } = await import('../listeners/DatabaseListener.js');
+    await enrichMessageLinkPreviews(message);
+    return res.json({ success: true });
+  } catch (error: any) {
+    logger.warn(`enrich-message failed for ${messageId}:`, error);
+    return res.status(500).json({ error: error.message || 'Enrichment failed' });
+  }
+});
 
 router.post('/', async (req, res) => {
   try {

--- a/federation-backend/src/services/LinkPreviewService.ts
+++ b/federation-backend/src/services/LinkPreviewService.ts
@@ -46,6 +46,9 @@ export interface EmbedPayload {
   html?: string;
   width?: number;
   height?: number;
+  /** The preview is essentially just media (GIF page etc.) - clients should
+      render the image itself, not a link card. */
+  mediaOnly?: boolean;
   fetchedAt: string;
   expiresAt: string;
   harmony?: {
@@ -76,6 +79,10 @@ const TTL_BY_PROVIDER: Record<EmbedProvider, number> = {
 };
 
 const USER_AGENT = 'HarmonyLinkPreview/1.0 (+https://har.mony.lol)';
+
+// Pages whose preview is really just the media (GIF sites). Combined with a
+// .gif og:image heuristic to set EmbedPayload.mediaOnly.
+const GIF_PAGE_HOSTS = new Set(['tenor.com', 'giphy.com', 'klipy.com']);
 
 const NON_AP_DOMAINS = new Set([
   'google.com', 'google.co.jp', 'google.co.uk', 'google.de', 'google.fr',
@@ -203,6 +210,17 @@ class LinkPreviewService {
     if (!payload.provider || payload.provider === 'generic') {
       payload.provider = provider;
     }
+    // GIF pages: the image IS the content - clients render it as bare media
+    // instead of a link card (Discord behavior).
+    if (!payload.mediaOnly && payload.image && payload.provider === 'generic') {
+      try {
+        const host = new URL(normalizedUrl).hostname.toLowerCase().replace(/^www\./, '');
+        if (GIF_PAGE_HOSTS.has(host) || /\.gif(\?|#|$)/i.test(payload.image)) {
+          payload.mediaOnly = true;
+        }
+      } catch { /* keep card rendering */ }
+    }
+
     const effectiveProvider = payload.provider;
     payload.fetchedAt = new Date().toISOString();
     payload.expiresAt = new Date(Date.now() + TTL_BY_PROVIDER[effectiveProvider]).toISOString();
@@ -284,6 +302,7 @@ class LinkPreviewService {
       title: media.title,
       siteName: 'Klipy',
       image: media.mediaUrl,
+      mediaOnly: true,
       width: media.width,
       height: media.height,
       fetchedAt: new Date().toISOString(),

--- a/src/components/UnifiedMessageContent.vue
+++ b/src/components/UnifiedMessageContent.vue
@@ -284,8 +284,27 @@
             v-else
             class="url-link url-link--unsafe"
           >{{ part.url }}</span>
+          <!-- Media-only embeds (GIF pages: tenor / giphy / klipy): the
+               resolved image IS the content, so render it exactly like a
+               direct image URL - no link-preview card chrome. -->
+          <div
+            v-if="mediaOnlyEmbedImage(part)"
+            class="media-container image-container"
+          >
+            <div class="media-frame">
+              <div v-if="!imageLoadedState[mediaOnlyEmbedImage(part)!]" class="media-skeleton image-skeleton"></div>
+              <img
+                :src="mediaOnlyEmbedImage(part)!"
+                @load="handleImageLoad(mediaOnlyEmbedImage(part)!)"
+                @click="$emit('open-lightbox', mediaOnlyEmbedImage(part)!)"
+                v-show="imageLoadedState[mediaOnlyEmbedImage(part)!]"
+                draggable="false"
+                class="content-image"
+              />
+            </div>
+          </div>
           <ProviderEmbedSwitch
-            v-if="resolveEmbedPayload(part) && !isImageUrl(part.url) && !isVideoUrl(part.url) && !isAudioUrl(part.url)"
+            v-else-if="resolveEmbedPayload(part) && !isImageUrl(part.url) && !isVideoUrl(part.url) && !isAudioUrl(part.url)"
             :payload="resolveEmbedPayload(part)!"
             :message-id="messageId"
             :key="`${messageId}-embed-${part.embedId || part.url}`"
@@ -958,6 +977,12 @@ export default defineComponent({
       return null;
     };
 
+    /** Image URL for media-only embeds (GIF pages), null for regular cards. */
+    const mediaOnlyEmbedImage = (part: MessagePart): string | null => {
+      const payload = resolveEmbedPayload(part);
+      return payload?.mediaOnly && payload.image ? payload.image : null;
+    };
+
     // Format mention display based on structured mention data
     const formatMentionDisplay = (mentionPart: any): string => {
       try {
@@ -1308,6 +1333,7 @@ export default defineComponent({
       isBridgedMention,
       getMentionTooltip,
       resolveEmbedPayload,
+      mediaOnlyEmbedImage,
       decrypting,
       handleDecryptClick,
       // GIF favorites

--- a/src/components/UnifiedMessageContent.vue
+++ b/src/components/UnifiedMessageContent.vue
@@ -288,19 +288,36 @@
                resolved image IS the content, so render it exactly like a
                direct image URL - no link-preview card chrome. -->
           <div
-            v-if="mediaOnlyEmbedImage(part)"
+            v-if="embedMedia(part)?.kind === 'image'"
             class="media-container image-container"
           >
             <div class="media-frame">
-              <div v-if="!imageLoadedState[mediaOnlyEmbedImage(part)!]" class="media-skeleton image-skeleton"></div>
+              <div v-if="!imageLoadedState[embedMedia(part)!.url]" class="media-skeleton image-skeleton"></div>
               <img
-                :src="mediaOnlyEmbedImage(part)!"
-                @load="handleImageLoad(mediaOnlyEmbedImage(part)!)"
-                @click="$emit('open-lightbox', mediaOnlyEmbedImage(part)!)"
-                v-show="imageLoadedState[mediaOnlyEmbedImage(part)!]"
+                :src="embedMedia(part)!.url"
+                @load="handleImageLoad(embedMedia(part)!.url)"
+                @click="$emit('open-lightbox', embedMedia(part)!.url)"
+                v-show="imageLoadedState[embedMedia(part)!.url]"
                 draggable="false"
                 class="content-image"
               />
+            </div>
+          </div>
+          <div
+            v-else-if="embedMedia(part)?.kind === 'video'"
+            class="media-container video-container"
+          >
+            <div class="media-frame">
+              <video
+                :src="embedMedia(part)!.url"
+                controls
+                loop
+                muted
+                autoplay
+                playsinline
+                class="content-video"
+                preload="metadata"
+              ></video>
             </div>
           </div>
           <ProviderEmbedSwitch
@@ -977,10 +994,23 @@ export default defineComponent({
       return null;
     };
 
-    /** Image URL for media-only embeds (GIF pages), null for regular cards. */
-    const mediaOnlyEmbedImage = (part: MessagePart): string | null => {
+    /**
+     * When an embed's resolved media IS the content (GIF pages like klipy /
+     * tenor / giphy), render it as real media instead of a link card.
+     *
+     * Decision is made HERE, from the media file itself, not only from the
+     * backend's mediaOnly flag: embeds are persisted in message metadata and
+     * cached for 24h server-side, so already-stored payloads (and hosts the
+     * backend heuristic doesn't know) must still upgrade to media rendering.
+     */
+    const embedMedia = (part: MessagePart): { kind: 'image' | 'video'; url: string } | null => {
       const payload = resolveEmbedPayload(part);
-      return payload?.mediaOnly && payload.image ? payload.image : null;
+      const media = payload?.image;
+      if (!media) return null;
+
+      if (/\.(mp4|webm|mov)(\?|#|$)/i.test(media)) return { kind: 'video', url: media };
+      if (payload.mediaOnly || /\.gif(\?|#|$)/i.test(media)) return { kind: 'image', url: media };
+      return null;
     };
 
     // Format mention display based on structured mention data
@@ -1333,7 +1363,7 @@ export default defineComponent({
       isBridgedMention,
       getMentionTooltip,
       resolveEmbedPayload,
-      mediaOnlyEmbedImage,
+      embedMedia,
       decrypting,
       handleDecryptClick,
       // GIF favorites

--- a/src/services/TodayDigestService.ts
+++ b/src/services/TodayDigestService.ts
@@ -396,64 +396,6 @@ class TodayDigestService {
       .trim()
   }
 
-  /**
-   * Summarize the digest on-device. Returns null when the API is missing,
-   * the model isn't downloaded, or summarization fails - callers treat the
-   * summary as strictly optional.
-   */
-  async summarizeDigest(digest: TodayDigest): Promise<string | null> {
-    const Summarizer = (globalThis as any).Summarizer
-    if (typeof Summarizer?.availability !== 'function') return null
-
-    try {
-      const availability = await Summarizer.availability()
-      if (availability !== 'available') {
-        debug.log(`Today digest: on-device model not ready (${availability})`)
-        return null
-      }
-
-      const summarizer = await Summarizer.create({
-        type: 'tldr',
-        format: 'plain-text',
-        length: 'short',
-      })
-
-      try {
-        const text = this.digestToPlainText(digest)
-        if (!text) return null
-        const summary = await summarizer.summarize(text, {
-          context: 'Activity digest for a chat and social app user. Address the reader directly.',
-        })
-        return typeof summary === 'string' && summary.trim() ? summary.trim() : null
-      } finally {
-        summarizer.destroy?.()
-      }
-    } catch (error) {
-      debug.warn('Today digest: on-device summarization failed:', error)
-      return null
-    }
-  }
-
-  private digestToPlainText(digest: TodayDigest): string {
-    const parts: string[] = []
-
-    if (digest.unreadMentions > 0) {
-      parts.push(`You have ${digest.unreadMentions} unread mentions waiting.`)
-    }
-    for (const p of digest.trendingPosts) {
-      const author = (p as any).author?.display_name || (p as any).author?.username
-      if (author) parts.push(`A post by ${author} is trending across the fediverse.`)
-    }
-    for (const p of digest.followedPosts) {
-      const author = (p as any).author?.display_name || (p as any).author?.username
-      const replies = (p as any).replies_count || 0
-      if (author && replies > 3) {
-        parts.push(`${author}, whom you follow, posted something with an active discussion (${replies} replies).`)
-      }
-    }
-
-    return parts.join('\n')
-  }
 }
 
 export const todayDigestService = new TodayDigestService()

--- a/src/types.ts
+++ b/src/types.ts
@@ -313,6 +313,9 @@ export interface EmbedPayload {
   html?: string;
   width?: number;
   height?: number;
+  /** The preview is essentially just media (GIF page etc.) - render the
+      image itself, not a link card. */
+  mediaOnly?: boolean;
   harmony?: HarmonyEmbedSummary;
   fediverse?: FediverseEmbedSummary;
   oEmbed?: Record<string, any>;

--- a/src/views/TodayView.vue
+++ b/src/views/TodayView.vue
@@ -24,38 +24,35 @@
              feature is on - a spinner while the model works beats the card
              popping in seconds after the page settled. -->
         <section
-          v-if="todayAiSummariesEnabled && (aiPending || aiSummary || highlights.length > 0)"
+          v-if="trendingAuthors.length > 0 || (todayAiSummariesEnabled && (highlightsPending || highlights.length > 0))"
           class="today-card span-full"
         >
           <div class="today-card-header">
             <Icon name="sparkles" :size="16" />
             <h2>Summary</h2>
-            <span class="on-device-badge" title="Generated locally - nothing leaves your device">On-device</span>
+            <span
+              v-if="todayAiSummariesEnabled"
+              class="on-device-badge"
+              title="Channel summaries are generated locally - nothing leaves your device"
+            >On-device AI</span>
           </div>
-          <div v-if="aiPending && !aiSummary && highlights.length === 0" class="ai-pending">
-            <LoadingSpinner :size="16" />
-            <span>Summarizing on this device…</span>
-          </div>
-          <div v-else-if="highlightsPending && highlights.length === 0" class="ai-pending">
+          <!-- Deterministic, id-based: rendered straight from the digest's
+               structured author data, never matched out of model prose. -->
+          <p v-if="trendingAuthors.length > 0" class="ai-summary-text">
+            <template v-for="(author, i) in trendingAuthors" :key="author.id">
+              <span v-if="i > 0">{{ i === trendingAuthors.length - 1 ? ' and ' : ', ' }}</span>
+              <button
+                class="user-chip"
+                :style="author.color ? { color: author.color } : undefined"
+                @click="openUserProfile(author)"
+              >{{ author.displayName }}</button>
+            </template>
+            <span> {{ trendingAuthors.length === 1 ? 'has' : 'have' }} posts trending across the fediverse.</span>
+          </p>
+          <div v-if="highlightsPending && highlights.length === 0" class="ai-pending">
             <LoadingSpinner :size="16" />
             <span>Summarizing channel conversations…</span>
           </div>
-          <p v-if="aiSummary" class="ai-summary-text">
-            <template v-for="(segment, i) in summarySegments" :key="i">
-              <button
-                v-if="segment.channel"
-                class="channel-pill inline-channel-pill"
-                @click="goToChannelId(segment.channel.serverId, segment.channel.channelId)"
-              >#{{ segment.channel.channelName }}</button>
-              <button
-                v-else-if="segment.user"
-                class="user-chip"
-                :style="segment.user.color ? { color: segment.user.color } : undefined"
-                @click="openUserProfile(segment.user)"
-              >{{ segment.text }}</button>
-              <template v-else>{{ segment.text }}</template>
-            </template>
-          </p>
           <!-- Same server-grouped presentation as Catch up -->
           <div v-for="group in highlightsByServer" :key="group.serverId" class="server-group">
             <div class="server-group-header">
@@ -255,9 +252,7 @@ const { todayAiSummariesEnabled } = useTodayDashboard()
 
 const loading = ref(false)
 const digest = ref<TodayDigest | null>(null)
-const aiSummary = ref<string | null>(null)
 const highlights = ref<ChannelHighlight[]>([])
-const aiPending = ref(false)
 const highlightsPending = ref(false)
 
 const greeting = computed(() => {
@@ -305,22 +300,18 @@ interface SummaryAuthor {
   isLocal?: boolean
 }
 
-interface SummarySegment {
-  text: string
-  channel: ActiveChannelEntry | null
-  user: SummaryAuthor | null
-}
-
-const escapeRegExp = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-
-/** Authors from the digest posts, keyed by the names the model may echo. */
-const summaryAuthorsByName = computed<Map<string, SummaryAuthor>>(() => {
-  const byName = new Map<string, SummaryAuthor>()
-  const posts = [...(digest.value?.trendingPosts || []), ...(digest.value?.followedPosts || [])]
-  for (const post of posts) {
+/**
+ * Authors with posts trending right now - straight from the digest's
+ * structured post data, keyed by profile id. No name matching against model
+ * prose: the "who's trending" line is rendered deterministically from these
+ * objects, and the on-device model only ever summarizes conversation content.
+ */
+const trendingAuthors = computed<SummaryAuthor[]>(() => {
+  const byId = new Map<string, SummaryAuthor>()
+  for (const post of digest.value?.trendingPosts || []) {
     const raw = (post as any).author
-    if (!raw?.id) continue
-    const author: SummaryAuthor = {
+    if (!raw?.id || byId.has(raw.id)) continue
+    byId.set(raw.id, {
       id: raw.id,
       displayName: raw.display_name || raw.username || 'Unknown',
       username: raw.username,
@@ -328,83 +319,9 @@ const summaryAuthorsByName = computed<Map<string, SummaryAuthor>>(() => {
       color: raw.color,
       domain: raw.domain,
       isLocal: raw.is_local,
-    }
-    const candidates = new Set<string>()
-    if (raw.display_name) {
-      candidates.add(String(raw.display_name))
-      // The model often shortens "Malika (arc auntiefication)" to "Malika".
-      const firstWord = String(raw.display_name).split(/[\s(]/)[0]
-      if (firstWord.length >= 3) candidates.add(firstWord)
-    }
-    if (raw.username && String(raw.username).length >= 3) candidates.add(String(raw.username))
-    for (const name of candidates) {
-      const key = name.toLowerCase()
-      if (!byName.has(key)) byName.set(key, author)
-    }
+    })
   }
-  return byName
-})
-
-/** Split plain text on known author names, producing user segments. */
-const splitByAuthors = (text: string): SummarySegment[] => {
-  const byName = summaryAuthorsByName.value
-  if (!text || byName.size === 0) return text ? [{ text, channel: null, user: null }] : []
-
-  const escaped = [...byName.keys()]
-    .sort((a, b) => b.length - a.length)
-    .map(escapeRegExp)
-  const pattern = new RegExp(`\\b(${escaped.join('|')})\\b`, 'gi')
-
-  const segments: SummarySegment[] = []
-  let lastIndex = 0
-  for (const match of text.matchAll(pattern)) {
-    const index = match.index ?? 0
-    if (index > lastIndex) segments.push({ text: text.slice(lastIndex, index), channel: null, user: null })
-    segments.push({ text: match[0], channel: null, user: byName.get(match[0].toLowerCase()) || null })
-    lastIndex = index + match[0].length
-  }
-  if (lastIndex < text.length) segments.push({ text: text.slice(lastIndex), channel: null, user: null })
-  return segments
-}
-
-/**
- * The model writes channel and author names as plain prose. Split the
- * free-text summary against the known names from the digest that fed it:
- * channels render as clickable "#channel" pills, post authors as avatar +
- * profile-colored chips that open their profile.
- */
-const summarySegments = computed<SummarySegment[]>(() => {
-  const text = aiSummary.value
-  if (!text) return []
-
-  const channels = digest.value?.activeChannels || []
-  if (channels.length === 0) return splitByAuthors(text)
-
-  const byName = new Map<string, ActiveChannelEntry>()
-  for (const c of channels) {
-    if (!byName.has(c.channelName.toLowerCase())) byName.set(c.channelName.toLowerCase(), c)
-  }
-
-  const escaped = [...byName.keys()]
-    .sort((a, b) => b.length - a.length) // longest first so e.g. "money" doesn't shadow "money-talk"
-    .map(escapeRegExp)
-  // Consume an optional leading "#" (with optional space, some models write
-  // "# gaming"): the pill supplies its own "#", so leaving the model's in the
-  // text produced "# #gaming".
-  const pattern = new RegExp(`#\\s?(${escaped.join('|')})\\b|\\b(${escaped.join('|')})\\b`, 'gi')
-
-  const segments: SummarySegment[] = []
-  let lastIndex = 0
-  for (const match of text.matchAll(pattern)) {
-    const index = match.index ?? 0
-    const name = (match[1] || match[2] || '').toLowerCase()
-    if (index > lastIndex) segments.push(...splitByAuthors(text.slice(lastIndex, index)))
-    segments.push({ text: match[0], channel: byName.get(name) || null, user: null })
-    lastIndex = index + match[0].length
-  }
-  if (lastIndex < text.length) segments.push(...splitByAuthors(text.slice(lastIndex)))
-
-  return segments
+  return [...byId.values()].slice(0, 4)
 })
 
 const channelsByServer = computed<ServerGroup[]>(() => {
@@ -432,12 +349,11 @@ const channelsByServer = computed<ServerGroup[]>(() => {
 
 const AI_CACHE_KEY = 'today-ai-cache'
 const AI_CACHE_MAX_AGE_MS = 12 * 3600_000
-const AI_CACHE_VERSION = 2
+const AI_CACHE_VERSION = 3
 
 interface AiCacheEntry {
   version: number
   signature: string
-  summary: string | null
   highlights: ChannelHighlight[]
   at: number
 }
@@ -460,27 +376,16 @@ const writeAiCache = (entry: AiCacheEntry) => {
 }
 
 const runAi = (snapshot: TodayDigest, signature: string) => {
-  const entry: AiCacheEntry = { version: AI_CACHE_VERSION, signature, summary: null, highlights: [], at: Date.now() }
-  aiPending.value = true
   highlightsPending.value = true
-  const summaryRun = todayDigestService.summarizeDigest(snapshot)
-    .then(summary => {
-      aiSummary.value = summary
-      entry.summary = summary
-      writeAiCache(entry)
-    })
-  const highlightsRun = todayDigestService.getChannelHighlights(snapshot.activeChannels)
+  todayDigestService.getChannelHighlights(snapshot.activeChannels)
     .then(result => {
       highlights.value = result
-      entry.highlights = result
-      writeAiCache(entry)
+      writeAiCache({ version: AI_CACHE_VERSION, signature, highlights: result, at: Date.now() })
     })
+    .catch(() => {})
     .finally(() => {
       highlightsPending.value = false
     })
-  Promise.allSettled([summaryRun, highlightsRun]).then(() => {
-    aiPending.value = false
-  })
 }
 
 const loadDigest = async (force = false) => {
@@ -489,7 +394,6 @@ const loadDigest = async (force = false) => {
     digest.value = await todayDigestService.getDigest()
 
     // AI output is strictly additive; never block the digest on it.
-    aiSummary.value = null
     highlights.value = []
     if (todayAiSummariesEnabled.value && digest.value) {
       const snapshot = digest.value
@@ -502,12 +406,10 @@ const loadDigest = async (force = false) => {
         cached.signature === signature
 
       if (cacheUsable) {
-        aiSummary.value = cached.summary
         highlights.value = cached.highlights
       } else if (!force && cached && Date.now() - cached.at < AI_CACHE_MAX_AGE_MS) {
-        // Inputs drifted (new messages since): show the cached text instantly,
-        // refresh it in the background.
-        aiSummary.value = cached.summary
+        // Inputs drifted (new messages since): show the cached highlights
+        // instantly, refresh them in the background.
         highlights.value = cached.highlights
         runAi(snapshot, signature)
       } else {


### PR DESCRIPTION
## Summary
- Recovers 2 commits (`aced257`, `ec987c0`) that got pushed to `multispan-bugfix` after PR #60 already squash-merged, so they never landed on master.
- Link preview: immediate enrichment for bridged messages, media-only rendering fix (klipy/tenor gifs render as real media instead of link cards).
- Bumps `federation-backend` and `bot-gateway` package.json to 1.2.0 to match root (already 1.2.0, matches the v1.2.0 announcement).

## Test plan
- [ ] Verify klipy/tenor links render as inline media, not link-preview cards
- [ ] Verify bridged Discord messages get link previews immediately
- [ ] Confirm no regressions vs what already merged in #60