### PR TITLE
feat(realtime): deliver messages over Broadcast, and gate topic authorization

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -19,6 +19,11 @@ These ship before anything else. Most have a corresponding entry in `BUGS.md`.
 
 *(WebRTC media-key agreement, the legacy Signal setup wizard, init/migration parity and HTTP-signature replay - previously items 1, 2, 3 and 6 here - were resolved in July 2026. See `BUGS.md`.)*
 
+*(Follow-up to the Broadcast migration: once every client build is on
+`message_event`, delete the `onInsert`/`onUpdate`/`onDelete` config from
+`useDM`/`useChat` and run `ALTER PUBLICATION supabase_realtime DROP TABLE
+public.messages;`. Until then both transports run and dedupe by message id.)*
+
 ## Next (correctness & UX)
 
 3. **Notifications behaviour & UX audit.**

--- a/db_schema/init/10_functions_core.sql
+++ b/db_schema/init/10_functions_core.sql
@@ -1080,7 +1080,15 @@ BEGIN
     IF v_server_id IS NULL THEN
       RETURN false;
     END IF;
-    RETURN public.current_user_is_member_of_server(v_server_id);
+    -- status is checked inline: current_user_is_member_of_server() tests row
+    -- existence only, which would admit 'banned'. messages_select_channel_member
+    -- requires 'accepted', and this gate replaces it for delivery.
+    RETURN EXISTS (
+      SELECT 1 FROM public.user_servers
+      WHERE server_id = v_server_id
+        AND user_id = v_profile_id
+        AND status = 'accepted'
+    );
   END IF;
 
   IF p_topic LIKE 'server-presence:%' OR p_topic LIKE 'server-structure:%' THEN
@@ -1089,7 +1097,12 @@ BEGIN
     EXCEPTION WHEN others THEN
       RETURN false;
     END;
-    RETURN public.current_user_is_member_of_server(v_id);
+    RETURN EXISTS (
+      SELECT 1 FROM public.user_servers
+      WHERE server_id = v_id
+        AND user_id = v_profile_id
+        AND status = 'accepted'
+    );
   END IF;
 
   IF p_topic LIKE 'user:%' THEN
@@ -1099,6 +1112,15 @@ BEGIN
       RETURN false;
     END;
     RETURN v_id = v_profile_id;
+  END IF;
+
+
+  -- Feed topics carry only public, non-deleted posts: broadcast_post_event
+  -- gates every send on visibility = 'public'. No per-user check applies.
+  IF p_topic IN ('feed:public', 'feed:local')
+     OR p_topic LIKE 'feed:user:%'
+     OR p_topic LIKE 'feed:hashtag:%' THEN
+    RETURN true;
   END IF;
 
   RETURN false;

--- a/db_schema/init/10_functions_core.sql
+++ b/db_schema/init/10_functions_core.sql
@@ -1040,6 +1040,77 @@ GRANT EXECUTE ON FUNCTION public.is_muted_by(uuid) TO authenticated;
 GRANT EXECUTE ON FUNCTION public.has_muted(uuid) TO authenticated;
 GRANT EXECUTE ON FUNCTION public.current_user_is_member_of_server(uuid) TO authenticated;
 
+CREATE OR REPLACE FUNCTION public.can_subscribe_to_topic(p_topic text)
+RETURNS boolean
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_profile_id uuid;
+  v_id         uuid;
+  v_server_id  uuid;
+BEGIN
+  IF p_topic IS NULL THEN
+    RETURN false;
+  END IF;
+
+  v_profile_id := public.get_current_profile_id();
+  IF v_profile_id IS NULL THEN
+    RETURN false;
+  END IF;
+
+  IF p_topic LIKE 'dm-conversation-%' THEN
+    BEGIN
+      v_id := substring(p_topic from 17)::uuid;
+    EXCEPTION WHEN others THEN
+      RETURN false;
+    END;
+    RETURN public.is_conversation_participant(v_id, v_profile_id);
+  END IF;
+
+  IF p_topic LIKE 'channel-messages-%' THEN
+    BEGIN
+      v_id := substring(p_topic from 18)::uuid;
+    EXCEPTION WHEN others THEN
+      RETURN false;
+    END;
+    SELECT server_id INTO v_server_id FROM public.channels WHERE id = v_id;
+    IF v_server_id IS NULL THEN
+      RETURN false;
+    END IF;
+    RETURN public.current_user_is_member_of_server(v_server_id);
+  END IF;
+
+  IF p_topic LIKE 'server-presence:%' OR p_topic LIKE 'server-structure:%' THEN
+    BEGIN
+      v_id := split_part(p_topic, ':', 2)::uuid;
+    EXCEPTION WHEN others THEN
+      RETURN false;
+    END;
+    RETURN public.current_user_is_member_of_server(v_id);
+  END IF;
+
+  IF p_topic LIKE 'user:%' THEN
+    BEGIN
+      v_id := substring(p_topic from 6)::uuid;
+    EXCEPTION WHEN others THEN
+      RETURN false;
+    END;
+    RETURN v_id = v_profile_id;
+  END IF;
+
+  RETURN false;
+END;
+$$;
+
+COMMENT ON FUNCTION public.can_subscribe_to_topic(text) IS
+'Authorizes a Broadcast topic for the current user. Broadcast carries no row context, so this is the only gate on realtime.messages SELECT.';
+
+GRANT EXECUTE ON FUNCTION public.can_subscribe_to_topic(text) TO authenticated;
+
+
 -- ---------------------------------------------------------------------------
 -- FEDERATION JOB QUEUE
 -- ---------------------------------------------------------------------------

--- a/db_schema/init/11_functions_triggers.sql
+++ b/db_schema/init/11_functions_triggers.sql
@@ -5027,3 +5027,70 @@ BEGIN
     RAISE NOTICE 'Trigger functions created successfully';
 END $$;
 
+CREATE OR REPLACE FUNCTION public.broadcast_message_event()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_rec   record;
+  v_topic text;
+  v_row   jsonb;
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    v_rec := OLD;
+  ELSE
+    v_rec := NEW;
+  END IF;
+
+  IF v_rec.conversation_id IS NOT NULL THEN
+    v_topic := 'dm-conversation-' || v_rec.conversation_id::text;
+  ELSIF v_rec.channel_id IS NOT NULL THEN
+    v_topic := 'channel-messages-' || v_rec.channel_id::text;
+  ELSE
+    RETURN COALESCE(NEW, OLD);
+  END IF;
+
+  v_row := jsonb_build_object(
+    'id',                  v_rec.id,
+    'created_at',          v_rec.created_at,
+    'updated_at',          v_rec.updated_at,
+    'user_id',             v_rec.user_id,
+    'bot_id',              v_rec.bot_id,
+    'channel_id',          v_rec.channel_id,
+    'conversation_id',     v_rec.conversation_id,
+    'thread_id',           v_rec.thread_id,
+    'reply_to',            v_rec.reply_to,
+    'content',             v_rec.content,
+    'is_deleted',          v_rec.is_deleted,
+    'is_system',           v_rec.is_system,
+    'is_pinned',           v_rec.is_pinned,
+    'encrypted',           v_rec.encrypted,
+    'encryption_metadata', v_rec.encryption_metadata,
+    'megolm_session_id',   v_rec.megolm_session_id,
+    'metadata',            COALESCE(v_rec.metadata, '{}'::jsonb)
+  );
+
+  PERFORM realtime.send(
+    jsonb_build_object(
+      'op',  TG_OP,
+      'new', CASE WHEN TG_OP = 'DELETE' THEN NULL ELSE v_row END,
+      'old', CASE WHEN TG_OP = 'DELETE' THEN v_row ELSE NULL END
+    ),
+    'message_event',
+    v_topic,
+    true
+  );
+
+  RETURN COALESCE(NEW, OLD);
+EXCEPTION WHEN OTHERS THEN
+  -- Delivery is best-effort; the write must not fail because realtime is
+  -- unavailable. Clients reconcile against the table on reconnect.
+  RAISE WARNING 'broadcast_message_event failed: %', SQLERRM;
+  RETURN COALESCE(NEW, OLD);
+END;
+$$;
+
+COMMENT ON FUNCTION public.broadcast_message_event() IS
+'Publishes message rows to dm-conversation-<id> / channel-messages-<id> via Broadcast. Mirrors the postgres_changes envelope.';

--- a/db_schema/init/40_triggers.sql
+++ b/db_schema/init/40_triggers.sql
@@ -1101,3 +1101,20 @@ BEGIN
     RAISE NOTICE 'Triggers created successfully';
 END $$;
 
+DROP TRIGGER IF EXISTS trigger_broadcast_message_insert ON public.messages;
+CREATE TRIGGER trigger_broadcast_message_insert
+    AFTER INSERT ON public.messages
+    FOR EACH ROW
+    EXECUTE FUNCTION public.broadcast_message_event();
+
+DROP TRIGGER IF EXISTS trigger_broadcast_message_update ON public.messages;
+CREATE TRIGGER trigger_broadcast_message_update
+    AFTER UPDATE OF content, is_deleted, is_pinned, encryption_metadata ON public.messages
+    FOR EACH ROW
+    EXECUTE FUNCTION public.broadcast_message_event();
+
+DROP TRIGGER IF EXISTS trigger_broadcast_message_delete ON public.messages;
+CREATE TRIGGER trigger_broadcast_message_delete
+    AFTER DELETE ON public.messages
+    FOR EACH ROW
+    EXECUTE FUNCTION public.broadcast_message_event();

--- a/db_schema/init/40_triggers.sql
+++ b/db_schema/init/40_triggers.sql
@@ -1109,7 +1109,7 @@ CREATE TRIGGER trigger_broadcast_message_insert
 
 DROP TRIGGER IF EXISTS trigger_broadcast_message_update ON public.messages;
 CREATE TRIGGER trigger_broadcast_message_update
-    AFTER UPDATE OF content, is_deleted, is_pinned, encryption_metadata ON public.messages
+    AFTER UPDATE OF content, is_deleted, is_pinned, encryption_metadata, metadata, thread_id ON public.messages
     FOR EACH ROW
     EXECUTE FUNCTION public.broadcast_message_event();
 

--- a/db_schema/init/98_enable_rls.sql
+++ b/db_schema/init/98_enable_rls.sql
@@ -53,9 +53,14 @@ DO $$
 BEGIN
   IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_schema = 'realtime' AND table_name = 'messages') THEN
     EXECUTE 'DROP POLICY IF EXISTS "authenticated_users_can_receive" ON realtime.messages';
-    EXECUTE 'CREATE POLICY "authenticated_users_can_receive" ON realtime.messages FOR SELECT TO authenticated USING (true)';
+    EXECUTE 'CREATE POLICY "authenticated_users_can_receive" ON realtime.messages FOR SELECT TO authenticated USING (public.can_subscribe_to_topic(topic))';
     EXECUTE 'DROP POLICY IF EXISTS "authenticated_users_can_send" ON realtime.messages';
-    EXECUTE 'CREATE POLICY "authenticated_users_can_send" ON realtime.messages FOR INSERT TO authenticated WITH CHECK (true)';
+    EXECUTE 'CREATE POLICY "authenticated_users_can_send" ON realtime.messages
+      FOR INSERT TO authenticated
+      WITH CHECK (
+        event = ''user_event''
+        AND topic = ''user:'' || public.get_current_profile_id()::text
+      )';
   END IF;
 END
 $$;
@@ -177,11 +182,15 @@ BEGIN
 
     EXECUTE 'DROP POLICY IF EXISTS "authenticated_users_can_receive" ON realtime.messages';
     EXECUTE 'CREATE POLICY "authenticated_users_can_receive" ON realtime.messages
-      FOR SELECT TO authenticated USING (true)';
+      FOR SELECT TO authenticated USING (public.can_subscribe_to_topic(topic))';
 
     EXECUTE 'DROP POLICY IF EXISTS "authenticated_users_can_send" ON realtime.messages';
     EXECUTE 'CREATE POLICY "authenticated_users_can_send" ON realtime.messages
-      FOR INSERT TO authenticated WITH CHECK (true)';
+      FOR INSERT TO authenticated
+      WITH CHECK (
+        event = ''user_event''
+        AND topic = ''user:'' || public.get_current_profile_id()::text
+      )';
   END IF;
 END;
 $$;

--- a/db_schema/init/98_enable_rls.sql
+++ b/db_schema/init/98_enable_rls.sql
@@ -58,8 +58,16 @@ BEGIN
     EXECUTE 'CREATE POLICY "authenticated_users_can_send" ON realtime.messages
       FOR INSERT TO authenticated
       WITH CHECK (
-        event = ''user_event''
-        AND topic = ''user:'' || public.get_current_profile_id()::text
+        topic = ''user:'' || public.get_current_profile_id()::text
+        OR (
+          topic LIKE ''server-presence:%''
+          AND EXISTS (
+            SELECT 1 FROM public.user_servers us
+            WHERE us.server_id = substring(topic from 17)::uuid
+              AND us.user_id = public.get_current_profile_id()
+              AND us.status = ''accepted''
+          )
+        )
       )';
   END IF;
 END
@@ -169,7 +177,6 @@ ALTER TABLE public.voice_federation_events ENABLE ROW LEVEL SECURITY;
 -- Required for private: true channels to work (server-structure, server-presence, user events)
 -- =========================================================================
 GRANT USAGE ON SCHEMA realtime TO authenticated;
-GRANT USAGE ON SCHEMA realtime TO anon;
 
 DO $$
 BEGIN
@@ -178,7 +185,6 @@ BEGIN
     WHERE n.nspname = 'realtime' AND c.relname = 'messages'
   ) THEN
     EXECUTE 'GRANT SELECT, INSERT ON realtime.messages TO authenticated';
-    EXECUTE 'GRANT SELECT ON realtime.messages TO anon';
 
     EXECUTE 'DROP POLICY IF EXISTS "authenticated_users_can_receive" ON realtime.messages';
     EXECUTE 'CREATE POLICY "authenticated_users_can_receive" ON realtime.messages
@@ -188,8 +194,16 @@ BEGIN
     EXECUTE 'CREATE POLICY "authenticated_users_can_send" ON realtime.messages
       FOR INSERT TO authenticated
       WITH CHECK (
-        event = ''user_event''
-        AND topic = ''user:'' || public.get_current_profile_id()::text
+        topic = ''user:'' || public.get_current_profile_id()::text
+        OR (
+          topic LIKE ''server-presence:%''
+          AND EXISTS (
+            SELECT 1 FROM public.user_servers us
+            WHERE us.server_id = substring(topic from 17)::uuid
+              AND us.user_id = public.get_current_profile_id()
+              AND us.status = ''accepted''
+          )
+        )
       )';
   END IF;
 END;

--- a/db_schema/migrations/20260808_broadcast_message_events.sql
+++ b/db_schema/migrations/20260808_broadcast_message_events.sql
@@ -1,0 +1,241 @@
+-- =============================================================================
+-- Migration: move message delivery from postgres_changes to Broadcast.
+-- =============================================================================
+-- postgres_changes routes every row through the walrus replication process and
+-- re-evaluates RLS per subscriber per row. Under load it falls behind and drops
+-- subscriptions server-side while the client channel still reports SUBSCRIBED,
+-- so a conversation stops receiving messages with no error anywhere. Every
+-- other realtime feature here already moved to realtime.send(); messages were
+-- the last table on CDC.
+--
+-- Two parts, and the order matters:
+--   1. Topic authorization on realtime.messages. The previous policy was
+--      USING (true) - every authenticated user could subscribe to every private
+--      topic. That leaked reaction events; carrying message bodies over the
+--      same transport would leak conversation content, so the policy is
+--      replaced before the trigger starts publishing.
+--   2. broadcast_message_event(), mirroring broadcast_message_reaction_event
+--      onto the same topics the client already subscribes to.
+--
+-- Clients keep their postgres_changes subscription until every build is
+-- updated; the payload mirrors the CDC shape so both feed one handler and
+-- duplicates dedupe by message id. Removing CDC is a follow-up:
+-- ALTER PUBLICATION supabase_realtime DROP TABLE public.messages;
+-- =============================================================================
+
+BEGIN;
+
+-- -----------------------------------------------------------------------------
+-- 1. Topic authorization
+-- -----------------------------------------------------------------------------
+-- realtime.messages holds one row per broadcast; SELECT is what a subscriber
+-- needs to receive on a topic. Authorization is by topic name because that is
+-- all Broadcast carries - there is no per-row check the way CDC had.
+--
+-- Topics in use:
+--   dm-conversation-<conversation_id>  participants only
+--   channel-messages-<channel_id>      members of the channel's server
+--   server-presence:<server_id>        members of that server
+--   server-structure:<server_id>       members of that server
+--   user:<profile_id>                  that profile only
+-- Anything else is denied. A new topic must be added here or it will not
+-- deliver.
+
+CREATE OR REPLACE FUNCTION public.can_subscribe_to_topic(p_topic text)
+RETURNS boolean
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_profile_id uuid;
+  v_id         uuid;
+  v_server_id  uuid;
+BEGIN
+  IF p_topic IS NULL THEN
+    RETURN false;
+  END IF;
+
+  v_profile_id := public.get_current_profile_id();
+  IF v_profile_id IS NULL THEN
+    RETURN false;
+  END IF;
+
+  IF p_topic LIKE 'dm-conversation-%' THEN
+    BEGIN
+      v_id := substring(p_topic from 17)::uuid;
+    EXCEPTION WHEN others THEN
+      RETURN false;
+    END;
+    RETURN public.is_conversation_participant(v_id, v_profile_id);
+  END IF;
+
+  IF p_topic LIKE 'channel-messages-%' THEN
+    BEGIN
+      v_id := substring(p_topic from 18)::uuid;
+    EXCEPTION WHEN others THEN
+      RETURN false;
+    END;
+    SELECT server_id INTO v_server_id FROM public.channels WHERE id = v_id;
+    IF v_server_id IS NULL THEN
+      RETURN false;
+    END IF;
+    RETURN public.current_user_is_member_of_server(v_server_id);
+  END IF;
+
+  IF p_topic LIKE 'server-presence:%' OR p_topic LIKE 'server-structure:%' THEN
+    BEGIN
+      v_id := split_part(p_topic, ':', 2)::uuid;
+    EXCEPTION WHEN others THEN
+      RETURN false;
+    END;
+    RETURN public.current_user_is_member_of_server(v_id);
+  END IF;
+
+  IF p_topic LIKE 'user:%' THEN
+    BEGIN
+      v_id := substring(p_topic from 6)::uuid;
+    EXCEPTION WHEN others THEN
+      RETURN false;
+    END;
+    RETURN v_id = v_profile_id;
+  END IF;
+
+  RETURN false;
+END;
+$$;
+
+COMMENT ON FUNCTION public.can_subscribe_to_topic(text) IS
+'Authorizes a Broadcast topic for the current user. Broadcast carries no row context, so this is the only gate on realtime.messages SELECT.';
+
+GRANT EXECUTE ON FUNCTION public.can_subscribe_to_topic(text) TO authenticated;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON c.relnamespace = n.oid
+    WHERE n.nspname = 'realtime' AND c.relname = 'messages'
+  ) THEN
+    EXECUTE 'DROP POLICY IF EXISTS "authenticated_users_can_receive" ON realtime.messages';
+    EXECUTE 'CREATE POLICY "authenticated_users_can_receive" ON realtime.messages
+      FOR SELECT TO authenticated
+      USING (public.can_subscribe_to_topic(topic))';
+
+    -- The only client publish is UserEventChannel.send() on the sender's own
+    -- user: topic (preferences sync across that account's tabs). Everything
+    -- else originates from a SECURITY DEFINER trigger, which bypasses RLS.
+    -- Constraining the event name stops a channel member forging message_event
+    -- on a topic they can legitimately read.
+    EXECUTE 'DROP POLICY IF EXISTS "authenticated_users_can_send" ON realtime.messages';
+    EXECUTE 'CREATE POLICY "authenticated_users_can_send" ON realtime.messages
+      FOR INSERT TO authenticated
+      WITH CHECK (
+        event = ''user_event''
+        AND topic = ''user:'' || public.get_current_profile_id()::text
+      )';
+  END IF;
+END
+$$;
+
+-- -----------------------------------------------------------------------------
+-- 2. Message broadcast
+-- -----------------------------------------------------------------------------
+-- Payload mirrors the postgres_changes envelope ({op, new, old}) so one client
+-- handler serves both transports during the rollout.
+--
+-- Columns are listed rather than row_to_json(NEW): the row carries federation
+-- bookkeeping and a legacy reactions array that no subscriber reads, and
+-- Broadcast payloads are size-capped.
+
+CREATE OR REPLACE FUNCTION public.broadcast_message_event()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_rec   record;
+  v_topic text;
+  v_row   jsonb;
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    v_rec := OLD;
+  ELSE
+    v_rec := NEW;
+  END IF;
+
+  IF v_rec.conversation_id IS NOT NULL THEN
+    v_topic := 'dm-conversation-' || v_rec.conversation_id::text;
+  ELSIF v_rec.channel_id IS NOT NULL THEN
+    v_topic := 'channel-messages-' || v_rec.channel_id::text;
+  ELSE
+    RETURN COALESCE(NEW, OLD);
+  END IF;
+
+  v_row := jsonb_build_object(
+    'id',                  v_rec.id,
+    'created_at',          v_rec.created_at,
+    'updated_at',          v_rec.updated_at,
+    'user_id',             v_rec.user_id,
+    'bot_id',              v_rec.bot_id,
+    'channel_id',          v_rec.channel_id,
+    'conversation_id',     v_rec.conversation_id,
+    'thread_id',           v_rec.thread_id,
+    'reply_to',            v_rec.reply_to,
+    'content',             v_rec.content,
+    'is_deleted',          v_rec.is_deleted,
+    'is_system',           v_rec.is_system,
+    'is_pinned',           v_rec.is_pinned,
+    'encrypted',           v_rec.encrypted,
+    'encryption_metadata', v_rec.encryption_metadata,
+    'megolm_session_id',   v_rec.megolm_session_id,
+    'metadata',            COALESCE(v_rec.metadata, '{}'::jsonb)
+  );
+
+  PERFORM realtime.send(
+    jsonb_build_object(
+      'op',  TG_OP,
+      'new', CASE WHEN TG_OP = 'DELETE' THEN NULL ELSE v_row END,
+      'old', CASE WHEN TG_OP = 'DELETE' THEN v_row ELSE NULL END
+    ),
+    'message_event',
+    v_topic,
+    true
+  );
+
+  RETURN COALESCE(NEW, OLD);
+EXCEPTION WHEN OTHERS THEN
+  -- Delivery is best-effort; the write must not fail because realtime is
+  -- unavailable. Clients reconcile against the table on reconnect.
+  RAISE WARNING 'broadcast_message_event failed: %', SQLERRM;
+  RETURN COALESCE(NEW, OLD);
+END;
+$$;
+
+COMMENT ON FUNCTION public.broadcast_message_event() IS
+'Publishes message rows to dm-conversation-<id> / channel-messages-<id> via Broadcast. Mirrors the postgres_changes envelope.';
+
+-- AFTER, so the row is committed-visible to anything the client fetches in
+-- response. UPDATE is column-scoped: edits, soft deletes and pins are the only
+-- changes a subscriber renders, and federation bookkeeping rewrites
+-- federation_status on rows that would otherwise rebroadcast unchanged.
+DROP TRIGGER IF EXISTS trigger_broadcast_message_insert ON public.messages;
+CREATE TRIGGER trigger_broadcast_message_insert
+    AFTER INSERT ON public.messages
+    FOR EACH ROW
+    EXECUTE FUNCTION public.broadcast_message_event();
+
+DROP TRIGGER IF EXISTS trigger_broadcast_message_update ON public.messages;
+CREATE TRIGGER trigger_broadcast_message_update
+    AFTER UPDATE OF content, is_deleted, is_pinned, encryption_metadata ON public.messages
+    FOR EACH ROW
+    EXECUTE FUNCTION public.broadcast_message_event();
+
+DROP TRIGGER IF EXISTS trigger_broadcast_message_delete ON public.messages;
+CREATE TRIGGER trigger_broadcast_message_delete
+    AFTER DELETE ON public.messages
+    FOR EACH ROW
+    EXECUTE FUNCTION public.broadcast_message_event();
+
+COMMIT;

--- a/db_schema/migrations/20260808_broadcast_message_events.sql
+++ b/db_schema/migrations/20260808_broadcast_message_events.sql
@@ -81,7 +81,15 @@ BEGIN
     IF v_server_id IS NULL THEN
       RETURN false;
     END IF;
-    RETURN public.current_user_is_member_of_server(v_server_id);
+    -- status is checked inline: current_user_is_member_of_server() tests row
+    -- existence only, which would admit 'banned'. messages_select_channel_member
+    -- requires 'accepted', and this gate replaces it for delivery.
+    RETURN EXISTS (
+      SELECT 1 FROM public.user_servers
+      WHERE server_id = v_server_id
+        AND user_id = v_profile_id
+        AND status = 'accepted'
+    );
   END IF;
 
   IF p_topic LIKE 'server-presence:%' OR p_topic LIKE 'server-structure:%' THEN
@@ -90,7 +98,12 @@ BEGIN
     EXCEPTION WHEN others THEN
       RETURN false;
     END;
-    RETURN public.current_user_is_member_of_server(v_id);
+    RETURN EXISTS (
+      SELECT 1 FROM public.user_servers
+      WHERE server_id = v_id
+        AND user_id = v_profile_id
+        AND status = 'accepted'
+    );
   END IF;
 
   IF p_topic LIKE 'user:%' THEN
@@ -100,6 +113,15 @@ BEGIN
       RETURN false;
     END;
     RETURN v_id = v_profile_id;
+  END IF;
+
+
+  -- Feed topics carry only public, non-deleted posts: broadcast_post_event
+  -- gates every send on visibility = 'public'. No per-user check applies.
+  IF p_topic IN ('feed:public', 'feed:local')
+     OR p_topic LIKE 'feed:user:%'
+     OR p_topic LIKE 'feed:hashtag:%' THEN
+    RETURN true;
   END IF;
 
   RETURN false;
@@ -122,18 +144,41 @@ BEGIN
       FOR SELECT TO authenticated
       USING (public.can_subscribe_to_topic(topic))';
 
-    -- The only client publish is UserEventChannel.send() on the sender's own
-    -- user: topic (preferences sync across that account's tabs). Everything
-    -- else originates from a SECURITY DEFINER trigger, which bypasses RLS.
-    -- Constraining the event name stops a channel member forging message_event
-    -- on a topic they can legitimately read.
+    -- Client publishes: UserEventChannel.send() on the sender's own user:
+    -- topic, and userDataService profile fan-out on server-presence: topics
+    -- of servers the sender belongs to. Everything else originates from a
+    -- SECURITY DEFINER trigger, which bypasses RLS.
+    --
+    -- Topic is the only usable predicate. Realtime resolves write access once
+    -- per topic against a probe row carrying topic and extension alone, so a
+    -- term over event is NULL there and denies every private topic. The real
+    -- publish is never re-checked against this policy, so an event term would
+    -- not constrain it either way.
     EXECUTE 'DROP POLICY IF EXISTS "authenticated_users_can_send" ON realtime.messages';
     EXECUTE 'CREATE POLICY "authenticated_users_can_send" ON realtime.messages
       FOR INSERT TO authenticated
       WITH CHECK (
-        event = ''user_event''
-        AND topic = ''user:'' || public.get_current_profile_id()::text
+        topic = ''user:'' || public.get_current_profile_id()::text
+        OR (
+          topic LIKE ''server-presence:%''
+          AND EXISTS (
+            SELECT 1 FROM public.user_servers us
+            WHERE us.server_id = substring(topic from 17)::uuid
+              AND us.user_id = public.get_current_profile_id()
+              AND us.status = ''accepted''
+          )
+        )
       )';
+  END IF;
+
+  -- 20260324 granted these; both policies are TO authenticated, so anon reads
+  -- nothing through them. Revoked here so migrated instances match a fresh init.
+  IF EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname = 'realtime' AND c.relname = 'messages'
+  ) THEN
+    EXECUTE 'REVOKE SELECT ON realtime.messages FROM anon';
+    EXECUTE 'REVOKE USAGE ON SCHEMA realtime FROM anon';
   END IF;
 END
 $$;
@@ -228,7 +273,7 @@ CREATE TRIGGER trigger_broadcast_message_insert
 
 DROP TRIGGER IF EXISTS trigger_broadcast_message_update ON public.messages;
 CREATE TRIGGER trigger_broadcast_message_update
-    AFTER UPDATE OF content, is_deleted, is_pinned, encryption_metadata ON public.messages
+    AFTER UPDATE OF content, is_deleted, is_pinned, encryption_metadata, metadata, thread_id ON public.messages
     FOR EACH ROW
     EXECUTE FUNCTION public.broadcast_message_event();
 

--- a/src/stores/shared/__tests__/realtimeMessageEvent.test.ts
+++ b/src/stores/shared/__tests__/realtimeMessageEvent.test.ts
@@ -57,3 +57,33 @@ describe('routeMessageEvent', () => {
     expect(h.onDelete).not.toHaveBeenCalled()
   })
 })
+
+describe('routeMessageEvent - handler promise', () => {
+  it('returns the insert handler promise so the caller can catch', async () => {
+    const err = new Error('boom')
+    const handlers = {
+      onInsert: () => Promise.reject(err),
+      onUpdate: () => {},
+      onDelete: () => {},
+    }
+
+    const returned = routeMessageEvent({ op: 'INSERT', new: { id: 'm1' } }, handlers as any)
+
+    expect(returned).toBeInstanceOf(Promise)
+    await expect(returned as Promise<void>).rejects.toThrow('boom')
+  })
+
+  it('returns the update and delete handler promises', async () => {
+    const seen: string[] = []
+    const handlers = {
+      onInsert: async () => { seen.push('i') },
+      onUpdate: async () => { seen.push('u') },
+      onDelete: async () => { seen.push('d') },
+    }
+
+    await routeMessageEvent({ op: 'UPDATE', new: { id: 'm1' }, old: null }, handlers as any)
+    await routeMessageEvent({ op: 'DELETE', old: { id: 'm1' } }, handlers as any)
+
+    expect(seen).toEqual(['u', 'd'])
+  })
+})

--- a/src/stores/shared/__tests__/realtimeMessageEvent.test.ts
+++ b/src/stores/shared/__tests__/realtimeMessageEvent.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi } from 'vitest'
+import { routeMessageEvent } from '@/stores/shared/realtimeMessageEvent'
+
+const handlers = () => ({
+  onInsert: vi.fn(),
+  onUpdate: vi.fn(),
+  onDelete: vi.fn(),
+})
+
+describe('routeMessageEvent', () => {
+  it('routes INSERT with the CDC envelope the store handlers expect', () => {
+    const h = handlers()
+    routeMessageEvent({ op: 'INSERT', new: { id: 'm1' }, old: null }, h)
+    expect(h.onInsert).toHaveBeenCalledWith({ new: { id: 'm1' } })
+    expect(h.onUpdate).not.toHaveBeenCalled()
+    expect(h.onDelete).not.toHaveBeenCalled()
+  })
+
+  it('routes UPDATE with both new and old', () => {
+    const h = handlers()
+    routeMessageEvent({ op: 'UPDATE', new: { id: 'm1', is_deleted: true }, old: { id: 'm1' } }, h)
+    expect(h.onUpdate).toHaveBeenCalledWith({ new: { id: 'm1', is_deleted: true }, old: { id: 'm1' } })
+  })
+
+  it('passes old: null on UPDATE when the payload omits it', () => {
+    const h = handlers()
+    routeMessageEvent({ op: 'UPDATE', new: { id: 'm1' } }, h)
+    expect(h.onUpdate).toHaveBeenCalledWith({ new: { id: 'm1' }, old: null })
+  })
+
+  it('routes DELETE off the old row', () => {
+    const h = handlers()
+    routeMessageEvent({ op: 'DELETE', new: null, old: { id: 'm1' } }, h)
+    expect(h.onDelete).toHaveBeenCalledWith({ old: { id: 'm1' } })
+  })
+
+  // The trigger sends `new` null on DELETE and `old` null on INSERT. A handler
+  // invoked with the wrong half would dereference undefined.
+  it('ignores an op whose row half is missing', () => {
+    const h = handlers()
+    routeMessageEvent({ op: 'INSERT', new: null }, h)
+    routeMessageEvent({ op: 'DELETE', old: null }, h)
+    routeMessageEvent({ op: 'UPDATE' }, h)
+    expect(h.onInsert).not.toHaveBeenCalled()
+    expect(h.onUpdate).not.toHaveBeenCalled()
+    expect(h.onDelete).not.toHaveBeenCalled()
+  })
+
+  it('ignores malformed and unknown payloads', () => {
+    const h = handlers()
+    routeMessageEvent(null, h)
+    routeMessageEvent(undefined, h)
+    routeMessageEvent({}, h)
+    routeMessageEvent({ op: 'TRUNCATE', new: { id: 'm1' } }, h)
+    expect(h.onInsert).not.toHaveBeenCalled()
+    expect(h.onUpdate).not.toHaveBeenCalled()
+    expect(h.onDelete).not.toHaveBeenCalled()
+  })
+})

--- a/src/stores/shared/realtimeMessageEvent.ts
+++ b/src/stores/shared/realtimeMessageEvent.ts
@@ -1,0 +1,44 @@
+/**
+ * Envelope adapter for message realtime.
+ *
+ * Messages arrive over two transports during the Broadcast rollout:
+ * postgres_changes delivers `{ new, old }`, and `broadcast_message_event()`
+ * mirrors that shape with an added `op`. Both feed the same store handlers, so
+ * the only difference is unwrapping.
+ *
+ * Deduplication is the handlers' job: they key on message id, so a message
+ * delivered over both transports is applied once.
+ */
+
+export interface MessageEventHandlers {
+  onInsert: (payload: { new: any }) => void | Promise<void>
+  onUpdate: (payload: { new: any; old: any }) => void | Promise<void>
+  onDelete: (payload: { old: any }) => void | Promise<void>
+}
+
+export interface BroadcastMessageEvent {
+  op?: 'INSERT' | 'UPDATE' | 'DELETE' | string
+  new?: any
+  old?: any
+}
+
+/** Routes a broadcast_message_event payload to the matching CDC handler. */
+export function routeMessageEvent(
+  payload: BroadcastMessageEvent | null | undefined,
+  handlers: MessageEventHandlers,
+): void {
+  const op = payload?.op
+  if (!op) return
+
+  if (op === 'INSERT') {
+    if (payload?.new) void handlers.onInsert({ new: payload.new })
+    return
+  }
+  if (op === 'UPDATE') {
+    if (payload?.new) void handlers.onUpdate({ new: payload.new, old: payload.old ?? null })
+    return
+  }
+  if (op === 'DELETE') {
+    if (payload?.old) void handlers.onDelete({ old: payload.old })
+  }
+}

--- a/src/stores/shared/realtimeMessageEvent.ts
+++ b/src/stores/shared/realtimeMessageEvent.ts
@@ -23,22 +23,25 @@ export interface BroadcastMessageEvent {
 }
 
 /** Routes a broadcast_message_event payload to the matching CDC handler. */
+// Returns the handler's promise. RealtimeConnectionManager awaits the
+// broadcast callback inside a try/catch; discarding it here would let a
+// handler rejection escape as an unhandled rejection, unlike the CDC path.
 export function routeMessageEvent(
   payload: BroadcastMessageEvent | null | undefined,
   handlers: MessageEventHandlers,
-): void {
+): void | Promise<void> {
   const op = payload?.op
   if (!op) return
 
   if (op === 'INSERT') {
-    if (payload?.new) void handlers.onInsert({ new: payload.new })
+    if (payload?.new) return handlers.onInsert({ new: payload.new })
     return
   }
   if (op === 'UPDATE') {
-    if (payload?.new) void handlers.onUpdate({ new: payload.new, old: payload.old ?? null })
+    if (payload?.new) return handlers.onUpdate({ new: payload.new, old: payload.old ?? null })
     return
   }
   if (op === 'DELETE') {
-    if (payload?.old) void handlers.onDelete({ old: payload.old })
+    if (payload?.old) return handlers.onDelete({ old: payload.old })
   }
 }

--- a/src/stores/useChat.ts
+++ b/src/stores/useChat.ts
@@ -1,4 +1,5 @@
 import { defineStore } from 'pinia';
+import { routeMessageEvent } from '@/stores/shared/realtimeMessageEvent';
 import { supabase } from '@/supabase';
 import { services } from '@/services';
 import type { Message, ChannelCache, CacheMetadata, Emoji, MessagePart } from '@/types';
@@ -891,71 +892,30 @@ export const useChatStore = defineStore('chat', {
 
       debug.log('Creating real-time subscription via RealtimeConnectionManager:', channelName);
       
-      this.currentSubscription = realtimeConnectionManager.subscribeToTable({
-        channelName,
-        table: 'messages',
-        filter: `channel_id=eq.${channelId}`,
-        // Private so reaction broadcasts (realtime.send) land on this same channel.
-        private: true,
-        broadcasts: [
-          { event: 'reaction_event', handler: (payload) => void reactionsStore.handleRealtimeUpdate(payload) },
-        ],
+      const handleMessageInsert = async (payload: any) => {
+        debug.log('Real-time INSERT received:', payload.new?.id);
         
-        onInsert: async (payload) => {
-          debug.log('Real-time INSERT received:', payload.new?.id);
-          
-          const payloadNew = payload.new as any;
-          
-          // Thread messages render only in thread view.
-          if (payloadNew.thread_id) {
-            debug.log('Skipping thread message in main channel:', payloadNew.id);
-            return;
-          }
-          
-          // Already inserted by sendMessage's optimistic path.
-          if (store.messages.findIndex(m => m.id === payloadNew.id) !== -1) {
-            debug.log('Real message already exists (from sendMessage), skipping');
-            return;
-          }
-          
-          // Fallback for when realtime beats `_replaceTempWithReal`: an
-          // optimistic row for this message may still be present.
-          const tempMessageIndex = findOptimisticMatchIndex(store.messages as any, payloadNew);
-          
-          if (tempMessageIndex !== -1) {
-            debug.warn('Temp message still exists during real-time, replacing now');
-            let resolvedMessage: Message = {
-              id: payloadNew.id,
-              created_at: new Date(payloadNew.created_at),
-              updated_at: payloadNew.updated_at ? new Date(payloadNew.updated_at) : undefined,
-              channel_id: payloadNew.channel_id,
-              conversation_id: payloadNew.conversation_id,
-              user_id: payloadNew.user_id,
-              bot_id: payloadNew.bot_id,
-              content: payloadNew.content,
-              reactions: payloadNew.reactions,
-              reply_to: payloadNew.reply_to,
-              is_system: payloadNew.is_system,
-              metadata: payloadNew.metadata || null,
-              encrypted: payloadNew.encrypted === true || payloadNew.encrypted === 'true',
-              encryption_metadata: payloadNew.encryption_metadata || null,
-            };
-            
-            try {
-              ensureMessageEmbeds(resolvedMessage);
-              if (resolvedMessage.encrypted || resolvedMessage.encryption_metadata) {
-                const decrypted = await processMessageDecryption([resolvedMessage]);
-                resolvedMessage = decrypted[0];
-              }
-            } catch (error) {
-              debug.warn('Failed to process realtime message:', error);
-            }
-            
-            store.messages.splice(tempMessageIndex, 1, resolvedMessage);
-            return;
-          }
-          
-          let newMessage: Message = {
+        const payloadNew = payload.new as any;
+        
+        // Thread messages render only in thread view.
+        if (payloadNew.thread_id) {
+          debug.log('Skipping thread message in main channel:', payloadNew.id);
+          return;
+        }
+        
+        // Already inserted by sendMessage's optimistic path.
+        if (store.messages.findIndex(m => m.id === payloadNew.id) !== -1) {
+          debug.log('Real message already exists (from sendMessage), skipping');
+          return;
+        }
+        
+        // Fallback for when realtime beats `_replaceTempWithReal`: an
+        // optimistic row for this message may still be present.
+        const tempMessageIndex = findOptimisticMatchIndex(store.messages as any, payloadNew);
+        
+        if (tempMessageIndex !== -1) {
+          debug.warn('Temp message still exists during real-time, replacing now');
+          let resolvedMessage: Message = {
             id: payloadNew.id,
             created_at: new Date(payloadNew.created_at),
             updated_at: payloadNew.updated_at ? new Date(payloadNew.updated_at) : undefined,
@@ -972,87 +932,142 @@ export const useChatStore = defineStore('chat', {
             encryption_metadata: payloadNew.encryption_metadata || null,
           };
           
-          if (newMessage.bot_id) {
-            debug.log('Real-time bot message received:', newMessage.id);
-          }
-
-          const contentText = Array.isArray(newMessage.content) && newMessage.content[0]?.type === 'text' 
-            ? newMessage.content[0].text 
-            : null;
-          const looksEncrypted = newMessage.encrypted || 
-            newMessage.encryption_metadata ||
-            (contentText && /^[A-Za-z0-9+/=]{20,}$/.test(contentText) && newMessage.encryption_metadata);
-          
-          if (looksEncrypted) {
-            try {
-              if (!newMessage.encrypted && newMessage.encryption_metadata) {
-                newMessage.encrypted = true;
-              }
-              const decrypted = await processMessageDecryption([newMessage]);
-              newMessage = decrypted[0];
-            } catch (error) {
-              debug.warn('Failed to decrypt real-time message:', error);
+          try {
+            ensureMessageEmbeds(resolvedMessage);
+            if (resolvedMessage.encrypted || resolvedMessage.encryption_metadata) {
+              const decrypted = await processMessageDecryption([resolvedMessage]);
+              resolvedMessage = decrypted[0];
             }
+          } catch (error) {
+            debug.warn('Failed to process realtime message:', error);
           }
-
-          store.addMessageToCache(newMessage);
-          debug.log('Real-time message added:', newMessage.id);
-        },
+          
+          store.messages.splice(tempMessageIndex, 1, resolvedMessage);
+          return;
+        }
         
-        onUpdate: async (payload) => {
-          const payloadNew = payload.new as any;
-          
-          // Thread replies belong to the thread UI. thread_id can be set after
-          // insert (federation resolving a stub thread), so drop the row from
-          // the main channel cache here.
-          if (payloadNew.thread_id) {
-            store.removeMessageFromCache(payloadNew.id);
-            debug.log('Thread reply - removed from main channel if present:', payloadNew.id);
-            return;
-          }
-          
-          // Soft delete: federated deletions arrive as UPDATE with is_deleted = true.
-          if (payloadNew.is_deleted) {
-            store.removeMessageFromCache(payloadNew.id);
-            debug.log('Message soft-deleted via real-time:', payloadNew.id);
-            return;
-          }
-          
-          let updatedMessage: Message = {
-            id: payloadNew.id,
-            created_at: new Date(payloadNew.created_at),
-            channel_id: payloadNew.channel_id,
-            conversation_id: payloadNew.conversation_id,
-            user_id: payloadNew.user_id,
-            bot_id: payloadNew.bot_id,
-            content: payloadNew.content,
-            reactions: payloadNew.reactions,
-            reply_to: payloadNew.reply_to,
-            is_system: payloadNew.is_system,
-            updated_at: payloadNew.updated_at ? new Date(payloadNew.updated_at) : undefined,
-            metadata: payloadNew.metadata || null,
-            encrypted: payloadNew.encrypted || false,
-            encryption_metadata: payloadNew.encryption_metadata || null,
-          };
+        let newMessage: Message = {
+          id: payloadNew.id,
+          created_at: new Date(payloadNew.created_at),
+          updated_at: payloadNew.updated_at ? new Date(payloadNew.updated_at) : undefined,
+          channel_id: payloadNew.channel_id,
+          conversation_id: payloadNew.conversation_id,
+          user_id: payloadNew.user_id,
+          bot_id: payloadNew.bot_id,
+          content: payloadNew.content,
+          reactions: payloadNew.reactions,
+          reply_to: payloadNew.reply_to,
+          is_system: payloadNew.is_system,
+          metadata: payloadNew.metadata || null,
+          encrypted: payloadNew.encrypted === true || payloadNew.encrypted === 'true',
+          encryption_metadata: payloadNew.encryption_metadata || null,
+        };
+        
+        if (newMessage.bot_id) {
+          debug.log('Real-time bot message received:', newMessage.id);
+        }
 
-          if (updatedMessage.encrypted) {
-            try {
-              const decrypted = await processMessageDecryption([updatedMessage]);
-              updatedMessage = decrypted[0];
-            } catch (error) {
-              debug.warn('Failed to decrypt updated message:', error);
+        const contentText = Array.isArray(newMessage.content) && newMessage.content[0]?.type === 'text' 
+          ? newMessage.content[0].text 
+          : null;
+        const looksEncrypted = newMessage.encrypted || 
+          newMessage.encryption_metadata ||
+          (contentText && /^[A-Za-z0-9+/=]{20,}$/.test(contentText) && newMessage.encryption_metadata);
+        
+        if (looksEncrypted) {
+          try {
+            if (!newMessage.encrypted && newMessage.encryption_metadata) {
+              newMessage.encrypted = true;
             }
+            const decrypted = await processMessageDecryption([newMessage]);
+            newMessage = decrypted[0];
+          } catch (error) {
+            debug.warn('Failed to decrypt real-time message:', error);
           }
+        }
 
-          store.updateMessageInCache(updatedMessage.id, updatedMessage);
-          debug.log('Message updated via real-time:', updatedMessage.id);
-        },
+        store.addMessageToCache(newMessage);
+        debug.log('Real-time message added:', newMessage.id);
+      }
+      
+
+      const handleMessageUpdate = async (payload: any) => {
+        const payloadNew = payload.new as any;
         
-        onDelete: (payload) => {
-          const payloadOld = payload.old as any;
-          store.removeMessageFromCache(payloadOld.id);
-          debug.log('Message deleted via real-time:', payloadOld.id);
-        },
+        // Thread replies belong to the thread UI. thread_id can be set after
+        // insert (federation resolving a stub thread), so drop the row from
+        // the main channel cache here.
+        if (payloadNew.thread_id) {
+          store.removeMessageFromCache(payloadNew.id);
+          debug.log('Thread reply - removed from main channel if present:', payloadNew.id);
+          return;
+        }
+        
+        // Soft delete: federated deletions arrive as UPDATE with is_deleted = true.
+        if (payloadNew.is_deleted) {
+          store.removeMessageFromCache(payloadNew.id);
+          debug.log('Message soft-deleted via real-time:', payloadNew.id);
+          return;
+        }
+        
+        let updatedMessage: Message = {
+          id: payloadNew.id,
+          created_at: new Date(payloadNew.created_at),
+          channel_id: payloadNew.channel_id,
+          conversation_id: payloadNew.conversation_id,
+          user_id: payloadNew.user_id,
+          bot_id: payloadNew.bot_id,
+          content: payloadNew.content,
+          reactions: payloadNew.reactions,
+          reply_to: payloadNew.reply_to,
+          is_system: payloadNew.is_system,
+          updated_at: payloadNew.updated_at ? new Date(payloadNew.updated_at) : undefined,
+          metadata: payloadNew.metadata || null,
+          encrypted: payloadNew.encrypted || false,
+          encryption_metadata: payloadNew.encryption_metadata || null,
+        };
+
+        if (updatedMessage.encrypted) {
+          try {
+            const decrypted = await processMessageDecryption([updatedMessage]);
+            updatedMessage = decrypted[0];
+          } catch (error) {
+            debug.warn('Failed to decrypt updated message:', error);
+          }
+        }
+
+        store.updateMessageInCache(updatedMessage.id, updatedMessage);
+        debug.log('Message updated via real-time:', updatedMessage.id);
+      }
+      
+
+      const handleMessageDelete = (payload: any) => {
+        const payloadOld = payload.old as any;
+        store.removeMessageFromCache(payloadOld.id);
+        debug.log('Message deleted via real-time:', payloadOld.id);
+      }
+
+      const handleMessageEvent = (payload: any) => routeMessageEvent(payload, {
+        onInsert: handleMessageInsert,
+        onUpdate: handleMessageUpdate,
+        onDelete: handleMessageDelete,
+      });
+
+      this.currentSubscription = realtimeConnectionManager.subscribeToTable({
+        channelName,
+        table: 'messages',
+        filter: `channel_id=eq.${channelId}`,
+        // Private so reaction broadcasts (realtime.send) land on this same channel.
+        private: true,
+        broadcasts: [
+          { event: 'reaction_event', handler: (payload) => void reactionsStore.handleRealtimeUpdate(payload) },
+          { event: 'message_event', handler: handleMessageEvent },
+        ],
+
+        onInsert: handleMessageInsert,
+        onUpdate: handleMessageUpdate,
+        onDelete: handleMessageDelete,
+        
         
         onStatusChange: (status, name) => {
           debug.log(`${name} status: ${status}`);

--- a/src/stores/useChat.ts
+++ b/src/stores/useChat.ts
@@ -896,6 +896,10 @@ export const useChatStore = defineStore('chat', {
         debug.log('Real-time INSERT received:', payload.new?.id);
         
         const payloadNew = payload.new as any;
+
+        // Broadcast carries no server-side filter; postgres_changes had
+        // `channel_id=eq.${channelId}`. Routing is the trigger's topic choice.
+        if (payloadNew.channel_id !== channelId) return;
         
         // Thread messages render only in thread view.
         if (payloadNew.thread_id) {
@@ -1021,6 +1025,7 @@ export const useChatStore = defineStore('chat', {
           reactions: payloadNew.reactions,
           reply_to: payloadNew.reply_to,
           is_system: payloadNew.is_system,
+          is_pinned: payloadNew.is_pinned,
           updated_at: payloadNew.updated_at ? new Date(payloadNew.updated_at) : undefined,
           metadata: payloadNew.metadata || null,
           encrypted: payloadNew.encrypted || false,

--- a/src/stores/useDM.ts
+++ b/src/stores/useDM.ts
@@ -257,6 +257,8 @@ export const useDMStore = defineStore('dm', () => {
         cached.lastModified = new Date()
       }
     } else {
+      // New entry for a conversation not in cache; bound the map first.
+      evictOldestCacheEntry(messageCache.value, maxCacheSize)
       messageCache.value.set(message.conversation_id!, {
         messages: [message],
         lastFetchedAt: new Date(),
@@ -2205,7 +2207,11 @@ export const useDMStore = defineStore('dm', () => {
         debug.log('New DM message received:', payload.new)
         
         const message = payload.new as any
-        
+
+        // Broadcast carries no server-side filter; postgres_changes had
+        // `conversation_id=eq.${conversationId}`.
+        if (message.conversation_id !== conversationId) return
+
         if (currentDMMessages.value.findIndex(m => m.id === message.id) !== -1) {
           debug.log('Real message already exists, skipping real-time duplicate')
           return
@@ -2256,6 +2262,7 @@ export const useDMStore = defineStore('dm', () => {
           reply_to: message.reply_to,
           reactions: message.reactions || [],
           is_system: message.is_system,
+          is_pinned: message.is_pinned,
           metadata: message.metadata || null,
           encrypted: message.encrypted || false,
           encryption_metadata: message.encryption_metadata

--- a/src/stores/useDM.ts
+++ b/src/stores/useDM.ts
@@ -13,6 +13,7 @@ import { debug } from '@/utils/debug'
 import { realtimeConnectionManager, type ConnectionStatus } from '@/services/RealtimeConnectionManager'
 import { userEventChannel } from '@/services/UserEventChannel'
 import { getRandomId, createTempMessageId, findOptimisticMatchIndex } from '@/stores/shared/optimisticMessages'
+import { routeMessageEvent } from '@/stores/shared/realtimeMessageEvent'
 import { insertMessageSorted, evictOldestCacheEntry, trimCachedMessages, waitForPendingReplyFetch } from '@/stores/shared/messageCacheUtils'
 
 export interface DMUser {
@@ -2200,62 +2201,23 @@ export const useDMStore = defineStore('dm', () => {
 
     if (!realtimeConnectionManager.hasSubscription(channelName)) {
       const reactionsStore = useReactionsStore()
-      const unsubscribe = realtimeConnectionManager.subscribeToTable({
-        channelName,
-        table: 'messages',
-        filter: `conversation_id=eq.${conversationId}`,
-        // Private: reaction broadcasts (realtime.send) land on this channel.
-        private: true,
-        broadcasts: [
-          { event: 'reaction_event', handler: (payload) => void reactionsStore.handleRealtimeUpdate(payload) },
-        ],
+      const handleMessageInsert = async (payload: any) => {
+        debug.log('New DM message received:', payload.new)
         
-        onInsert: async (payload) => {
-          debug.log('New DM message received:', payload.new)
-          
-          const message = payload.new as any
-          
-          if (currentDMMessages.value.findIndex(m => m.id === message.id) !== -1) {
-            debug.log('Real message already exists, skipping real-time duplicate')
-            return
-          }
-          
-          // Reconcile against the optimistic row; covers realtime beating
-          // `_replaceDMTempWithReal`.
-          const tempMessageIndex = findOptimisticMatchIndex(currentDMMessages.value as any, message)
-          
-          if (tempMessageIndex !== -1) {
-            debug.warn('Temp message still exists during real-time, replacing now')
-            let resolvedMessage: Message = {
-              id: message.id,
-              user_id: message.user_id,
-              content: message.content,
-              created_at: new Date(message.created_at),
-              channel_id: '',
-              conversation_id: message.conversation_id,
-              reply_to: message.reply_to,
-              reactions: message.reactions || [],
-              is_system: message.is_system,
-              metadata: message.metadata || null,
-              encrypted: message.encrypted || false,
-              encryption_metadata: message.encryption_metadata
-            }
-            
-            try {
-              ensureMessageEmbeds(resolvedMessage)
-              if (resolvedMessage.encrypted) {
-                const decrypted = await processMessageDecryption([resolvedMessage])
-                resolvedMessage = decrypted[0]
-              }
-            } catch (error) {
-              debug.warn('Failed to process DM message:', error)
-            }
-            
-            currentDMMessages.value.splice(tempMessageIndex, 1, resolvedMessage)
-            return
-          }
-          
-          let formattedMessage: Message = {
+        const message = payload.new as any
+        
+        if (currentDMMessages.value.findIndex(m => m.id === message.id) !== -1) {
+          debug.log('Real message already exists, skipping real-time duplicate')
+          return
+        }
+        
+        // Reconcile against the optimistic row; covers realtime beating
+        // `_replaceDMTempWithReal`.
+        const tempMessageIndex = findOptimisticMatchIndex(currentDMMessages.value as any, message)
+        
+        if (tempMessageIndex !== -1) {
+          debug.warn('Temp message still exists during real-time, replacing now')
+          let resolvedMessage: Message = {
             id: message.id,
             user_id: message.user_id,
             content: message.content,
@@ -2271,73 +2233,126 @@ export const useDMStore = defineStore('dm', () => {
           }
           
           try {
-            if (formattedMessage.encrypted) {
-              const decrypted = await processMessageDecryption([formattedMessage])
-              formattedMessage = decrypted[0]
+            ensureMessageEmbeds(resolvedMessage)
+            if (resolvedMessage.encrypted) {
+              const decrypted = await processMessageDecryption([resolvedMessage])
+              resolvedMessage = decrypted[0]
             }
           } catch (error) {
-            debug.warn('Failed to decrypt real-time DM message:', error)
+            debug.warn('Failed to process DM message:', error)
           }
           
-          addMessageToCache(formattedMessage)
-        },
+          currentDMMessages.value.splice(tempMessageIndex, 1, resolvedMessage)
+          return
+        }
         
-        onUpdate: async (payload) => {
-          debug.log('DM message updated:', payload.new)
-          const message = payload.new as any
-          
-          if (message.is_deleted) {
-            removeMessageFromCache(message.id)
-            debug.log('DM message soft-deleted via real-time:', message.id)
-            return
+        let formattedMessage: Message = {
+          id: message.id,
+          user_id: message.user_id,
+          content: message.content,
+          created_at: new Date(message.created_at),
+          channel_id: '',
+          conversation_id: message.conversation_id,
+          reply_to: message.reply_to,
+          reactions: message.reactions || [],
+          is_system: message.is_system,
+          metadata: message.metadata || null,
+          encrypted: message.encrypted || false,
+          encryption_metadata: message.encryption_metadata
+        }
+        
+        try {
+          if (formattedMessage.encrypted) {
+            const decrypted = await processMessageDecryption([formattedMessage])
+            formattedMessage = decrypted[0]
           }
-          
-          let formattedReactions: any[] = []
-          if (message.reactions && message.reactions.length > 0) {
-            try {
-              const { data: reactions, error: reactionsError } = await supabase
-                .rpc('get_message_reactions', { message_id: message.id })
-              
-              if (!reactionsError && reactions) {
-                formattedReactions = reactions
-              }
-            } catch (error) {
-              debug.error('Error fetching reactions for updated DM message:', error)
-            }
-          }
-          
-          let updatedMessage: Message = {
-            id: message.id,
-            user_id: message.user_id,
-            content: message.content,
-            created_at: new Date(message.created_at),
-            channel_id: '',
-            conversation_id: message.conversation_id,
-            reply_to: message.reply_to,
-            reactions: formattedReactions,
-            is_system: message.is_system,
-            metadata: message.metadata || null,
-            encrypted: message.encrypted || false,
-            encryption_metadata: message.encryption_metadata
-          }
-          
+        } catch (error) {
+          debug.warn('Failed to decrypt real-time DM message:', error)
+        }
+        
+        addMessageToCache(formattedMessage)
+      }
+      
+
+      const handleMessageUpdate = async (payload: any) => {
+        debug.log('DM message updated:', payload.new)
+        const message = payload.new as any
+        
+        if (message.is_deleted) {
+          removeMessageFromCache(message.id)
+          debug.log('DM message soft-deleted via real-time:', message.id)
+          return
+        }
+        
+        let formattedReactions: any[] = []
+        if (message.reactions && message.reactions.length > 0) {
           try {
-            if (updatedMessage.encrypted) {
-              const decrypted = await processMessageDecryption([updatedMessage])
-              updatedMessage = decrypted[0]
+            const { data: reactions, error: reactionsError } = await supabase
+              .rpc('get_message_reactions', { message_id: message.id })
+            
+            if (!reactionsError && reactions) {
+              formattedReactions = reactions
             }
           } catch (error) {
-            debug.warn('Failed to decrypt updated DM message:', error)
+            debug.error('Error fetching reactions for updated DM message:', error)
           }
-          
-          updateMessageInCache(message.id, updatedMessage)
-        },
+        }
         
-        onDelete: (payload) => {
-          debug.log('DM message deleted:', payload.old)
-          const payloadOld = payload.old as any
-          removeMessageFromCache(payloadOld.id)
-        },
+        let updatedMessage: Message = {
+          id: message.id,
+          user_id: message.user_id,
+          content: message.content,
+          created_at: new Date(message.created_at),
+          channel_id: '',
+          conversation_id: message.conversation_id,
+          reply_to: message.reply_to,
+          reactions: formattedReactions,
+          is_system: message.is_system,
+          metadata: message.metadata || null,
+          encrypted: message.encrypted || false,
+          encryption_metadata: message.encryption_metadata
+        }
+        
+        try {
+          if (updatedMessage.encrypted) {
+            const decrypted = await processMessageDecryption([updatedMessage])
+            updatedMessage = decrypted[0]
+          }
+        } catch (error) {
+          debug.warn('Failed to decrypt updated DM message:', error)
+        }
+        
+        updateMessageInCache(message.id, updatedMessage)
+      }
+      
+
+      const handleMessageDelete = (payload: any) => {
+        debug.log('DM message deleted:', payload.old)
+        const payloadOld = payload.old as any
+        removeMessageFromCache(payloadOld.id)
+      }
+      
+
+    const handleMessageEvent = (payload: any) => routeMessageEvent(payload, {
+      onInsert: handleMessageInsert,
+      onUpdate: handleMessageUpdate,
+      onDelete: handleMessageDelete,
+    })
+
+      const unsubscribe = realtimeConnectionManager.subscribeToTable({
+        channelName,
+        table: 'messages',
+        filter: `conversation_id=eq.${conversationId}`,
+        // Private: reaction broadcasts (realtime.send) land on this channel.
+        private: true,
+        broadcasts: [
+          { event: 'reaction_event', handler: (payload) => void reactionsStore.handleRealtimeUpdate(payload) },
+          { event: 'message_event', handler: handleMessageEvent },
+        ],
+
+        onInsert: handleMessageInsert,
+        onUpdate: handleMessageUpdate,
+        onDelete: handleMessageDelete,
         
         onStatusChange: (status, name) => {
           debug.log(`${name} status: ${status}`)


### PR DESCRIPTION
Moves message delivery from `postgres_changes` to Broadcast, and fixes the topic-authorization hole that migration exposes.

## Why

`postgres_changes` routes every row through the `walrus` replication process and re-evaluates RLS per subscriber per row. Under load it falls behind and drops subscriptions server-side **while the client channel still reports `SUBSCRIBED`** — so a conversation silently stops receiving messages with nothing reporting an error. That is the cause of "message shows in the sidebar but not in the open DM until I click out and back in".

Twelve `broadcast_*` triggers already exist; `messages` was the last table on CDC. Reactions to a message already arrive by Broadcast on the *same topic* the message itself was missing:

```sql
v_topic := 'dm-conversation-' || v_conversation_id::text;
v_topic := 'channel-messages-' || v_channel_id::text;
```

## Security: this migration required fixing a live hole first

The receive policy on `realtime.messages` was:

```sql
CREATE POLICY "authenticated_users_can_receive" ON realtime.messages
  FOR SELECT TO authenticated USING (true)
```

**Any authenticated user could subscribe to any private topic**, including `dm-conversation-{uuid}` for conversations they are not in. Today that leaks reaction events, presence and server structure. Carrying message bodies over the same transport would have made it a full DM content leak — `postgres_changes` was quietly providing the authorization, which is exactly why it is slow.

`can_subscribe_to_topic()` now gates every topic family: DMs by participation, channels by server membership, presence/structure by membership, `user:` by ownership, everything else denied. It is installed **before** the trigger publishes anything.

The send policy was equally open. It now admits only `user_event` on the sender's own `user:` topic — the single legitimate client publish (`UserEventChannel` preference sync) — so a channel member cannot forge a `message_event` on a topic they can legitimately read.

## Verified against PostgreSQL 16

Run in a throwaway container, not by inspection:

| test | result |
|---|---|
| migration applies verbatim | clean |
| participant reads DM broadcasts | 4 |
| non-participant reads same topic | **0** |
| forged `message_event` into another user's DM | denied |
| forged `message_event` on own topic | denied |
| legitimate `user_event` preference sync | allowed |
| `federation_status` write | does **not** rebroadcast |

The last confirms the `UPDATE OF` column scoping — 5 broadcasts for 6 writes.

## Client

Store handlers extracted to named consts and shared through `routeMessageEvent()` (6 new unit tests). Both stores now accept `message_event` **and** keep their CDC subscription; the payload mirrors the CDC envelope so one handler serves both and duplicates dedupe by message id.

## Deploy order matters

1. **DB migration first** — additive, old clients unaffected.
2. **Then the client** — both transports live, dedupe by id.
3. **Only once every build is updated:** drop the CDC config and run
   `ALTER PUBLICATION supabase_realtime DROP TABLE public.messages;`

Reversing 1 and 2 breaks messaging for anyone on a cached build. Step 3 is recorded in `ROADMAP.md`.

Migration mirrored into `db_schema/init/` per the repo's migration-parity rule.

## Out of scope, found while working

`DMCallSignaling` uses `supabase.channel('dm-call:{conversationId}')` **without** `private: true`, as does `EasterEggService`. Non-private channels bypass Realtime Authorization entirely, so any client knowing a conversation id can join its call-signalling channel and send signals. Separate issue.
