### PR TITLE
fix(perf): close review findings in the cache bounds

### DIFF
--- a/src/components/EmojiPopup.vue
+++ b/src/components/EmojiPopup.vue
@@ -958,8 +958,7 @@ onMounted(async () => {
 
 onUnmounted(() => {
   isUnmounted = true;
-  // Registration is deferred 100ms; without clearing, unmounting inside that
-  // window leaves listeners nothing can remove.
+  // Registration is deferred 100ms; unmounting inside that window must clear it.
   if (outsideListenerTimeout !== null) {
     clearTimeout(outsideListenerTimeout);
     outsideListenerTimeout = null;

--- a/src/components/admin/InstanceConfig.vue
+++ b/src/components/admin/InstanceConfig.vue
@@ -829,8 +829,7 @@ const saveConfig = async () => {
   }
 }
 
-// Refs rather than computeds: the object URL of the superseded file must be revoked,
-// which a computed has no hook for.
+// Refs, not computeds: the superseded file's object URL must be revoked.
 const instanceIconPreviewUrl = ref<string | null>(null)
 const instanceBannerPreviewUrl = ref<string | null>(null)
 

--- a/src/components/settings/user/VoiceSettingsInline.vue
+++ b/src/components/settings/user/VoiceSettingsInline.vue
@@ -336,9 +336,8 @@ let testStream: MediaStream | null = null;
 let testAudioContext: AudioContext | null = null;
 let testRafId: number | null = null;
 let testTimeoutId: ReturnType<typeof setTimeout> | null = null;
-// Bumped by every start and stop. A getUserMedia that resolves after its
-// run was superseded must discard its stream instead of overwriting the
-// handles of the run that replaced it.
+// Bumped by every start and stop. A getUserMedia resolving after its run was
+// superseded discards its stream rather than overwriting the current handles.
 let testGeneration = 0;
 
 const testMicrophone = async () => {

--- a/src/components/voice/VoiceSettingsPanel.vue
+++ b/src/components/voice/VoiceSettingsPanel.vue
@@ -413,9 +413,8 @@ export default defineComponent({
     let testAudioContext: AudioContext | null = null;
     let testRafId: number | null = null;
     let testTimeoutId: ReturnType<typeof setTimeout> | null = null;
-// Bumped by every start and stop. A getUserMedia that resolves after its
-// run was superseded must discard its stream instead of overwriting the
-// handles of the run that replaced it.
+// Bumped by every start and stop. A getUserMedia resolving after its run was
+// superseded discards its stream rather than overwriting the current handles.
 let testGeneration = 0;
 
     const testMicrophone = async () => {

--- a/src/composables/__tests__/useUserData.listeners.test.ts
+++ b/src/composables/__tests__/useUserData.listeners.test.ts
@@ -1,8 +1,4 @@
-/**
- * useUserData is called from 43 sites, several of them per message or per
- * mention. Registering service listeners per call leaked seven per invocation
- * and was the mechanism behind progressive session slowdown.
- */
+// Service listeners bind once at module scope, not per useUserData() call.
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 const addEventListener = vi.fn()

--- a/src/composables/useUserData.ts
+++ b/src/composables/useUserData.ts
@@ -12,12 +12,8 @@ import { UserStatus, type DisplayNamePart } from '@/types'
 import { getAvatarUrl } from '@/utils/avatarUtils'
 import { debug } from '@/utils/debug'
 
-// Module scope, not per call. userDataService is a singleton and every caller
-// wants the same signal, so one counter and one set of listeners serve all of
-// them. Registering per call leaked seven listeners per invocation, each
-// closing over that call's setup scope; across 43 call sites - several of them
-// per message or per mention - a channel switch cost hundreds of permanent
-// listeners, and every 'user-updated' emit then fanned out across all of them.
+// Module scope, not per call. userDataService is a singleton; one counter and
+// one listener set serve every caller.
 const forceUpdate = ref(0)
 
 const triggerUpdate = () => {
@@ -34,8 +30,7 @@ const SERVICE_EVENTS = [
   'global-presence-updated',
 ] as const
 
-// Bound once for the module's lifetime. The service outlives every consumer,
-// so there is nothing to unbind.
+// Bound once for the module's lifetime; the service outlives every consumer.
 const isInitialized = ref(false)
 
 const bindServiceListeners = () => {

--- a/src/stores/shared/__tests__/messageCacheUtils.test.ts
+++ b/src/stores/shared/__tests__/messageCacheUtils.test.ts
@@ -13,8 +13,17 @@ const mk = (i: number): Message =>
     created_at: new Date(1700000000000 + i * 1000).toISOString(),
   }) as any
 
-const cacheOf = (id: string, count: number) =>
-  new Map([[id, { messages: Array.from({ length: count }, (_, i) => mk(i)) }]])
+const entry = (count: number, allLoaded = true) => {
+  const messages = Array.from({ length: count }, (_, i) => mk(i))
+  return {
+    messages,
+    lastFetchedAt: new Date(1700000000000),
+    oldestMessageId: messages[0]?.id ?? null,
+    allMessagesLoaded: allLoaded,
+  }
+}
+
+const cacheOf = (id: string, count: number) => new Map([[id, entry(count)]])
 
 describe('trimCachedMessages', () => {
   it('bounds a conversation that grew past the cap', () => {
@@ -63,7 +72,7 @@ describe('trimCachedMessages', () => {
 
   it('does not touch other conversations', () => {
     const cache = cacheOf('c1', 5000)
-    cache.set('c2', { messages: Array.from({ length: 4000 }, (_, i) => mk(i)) })
+    cache.set('c2', entry(4000))
 
     trimCachedMessages(cache, 'c1')
 
@@ -79,5 +88,33 @@ describe('trimCachedMessages', () => {
 
     expect(arr.length).toBe(MAX_CACHED_MESSAGES + 1)
     expect(arr[arr.length - 1].id).toBe('m2000')
+  })
+
+  it('reopens pagination when it drops messages', () => {
+    const cache = cacheOf('c1', 1000)
+
+    trimCachedMessages(cache, 'c1')
+
+    // allMessagesLoaded is restored verbatim on cache re-entry and gates the
+    // scroll-up sentinel; leaving it set strands the trimmed history.
+    expect(cache.get('c1')!.allMessagesLoaded).toBe(false)
+  })
+
+  it('moves oldestMessageId to the new front of the array', () => {
+    const cache = cacheOf('c1', 1000)
+
+    trimCachedMessages(cache, 'c1')
+
+    const kept = cache.get('c1')!
+    expect(kept.oldestMessageId).toBe(kept.messages[0].id)
+  })
+
+  it('leaves pagination state alone when nothing is dropped', () => {
+    const cache = cacheOf('c1', 10)
+
+    trimCachedMessages(cache, 'c1')
+
+    expect(cache.get('c1')!.allMessagesLoaded).toBe(true)
+    expect(cache.get('c1')!.oldestMessageId).toBe('m0')
   })
 })

--- a/src/stores/shared/__tests__/reactionEngine.test.ts
+++ b/src/stores/shared/__tests__/reactionEngine.test.ts
@@ -198,6 +198,7 @@ describe('reactionEngine', () => {
 
 describe('cache bounding', () => {
   const MAX = 500
+  const TTL = 30000
   beforeEach(() => vi.useFakeTimers())
   afterEach(() => vi.useRealTimers())
 
@@ -211,6 +212,7 @@ describe('cache bounding', () => {
         batch[`m${page}-${i}`] = [{ key: '+1', count: 1, reacted: false }]
       }
       engine.bulkSet(batch)
+      vi.advanceTimersByTime(TTL + 1)
     }
 
     expect(engine.reactionsByEntity.size).toBeLessThanOrEqual(MAX)
@@ -220,6 +222,7 @@ describe('cache bounding', () => {
     const { engine } = setup()
     for (let i = 0; i < 800; i++) {
       engine.setReactions(`s${i}`, [{ key: '+1', count: 1, reacted: false }])
+      if (i % 100 === 0) vi.advanceTimersByTime(TTL + 1)
     }
     expect(engine.reactionsByEntity.size).toBeLessThanOrEqual(MAX)
   })
@@ -228,9 +231,35 @@ describe('cache bounding', () => {
     const { engine } = setup()
     for (let i = 0; i < 700; i++) {
       engine.setReactions(`e${i}`, [{ key: '+1', count: 1, reacted: false }])
+      if (i % 100 === 0) vi.advanceTimersByTime(TTL + 1)
     }
     expect(engine.getReactions.value('e699')).toHaveLength(1)
     expect(engine.getReactions.value('e0')).toHaveLength(0)
+  })
+
+  it('keeps entries inside the TTL even past the cap', () => {
+    const { engine } = setup()
+    // The working set is the viewport plus recent scrollback. Evicting it
+    // costs an RPC per reaction_event per viewer, which applyRealtimeDelta
+    // exists to avoid, so the TTL wins over the cap.
+    for (let i = 0; i < 1200; i++) {
+      engine.setReactions(`hot${i}`, [{ key: '+1', count: 1, reacted: false }])
+    }
+    expect(engine.reactionsByEntity.size).toBe(1200)
+    expect(engine.getReactions.value('hot0')).toHaveLength(1)
+  })
+
+  it('evicts once the working set ages past the TTL', () => {
+    const { engine } = setup()
+    for (let i = 0; i < 1200; i++) {
+      engine.setReactions(`hot${i}`, [{ key: '+1', count: 1, reacted: false }])
+    }
+    expect(engine.reactionsByEntity.size).toBe(1200)
+
+    vi.advanceTimersByTime(TTL + 1)
+    engine.setReactions('trigger', [{ key: '+1', count: 1, reacted: false }])
+
+    expect(engine.reactionsByEntity.size).toBeLessThanOrEqual(MAX + 1)
   })
 
   it('does not retain every entity the user has reacted to', async () => {
@@ -240,9 +269,11 @@ describe('cache bounding', () => {
 
     // Pending reconciles are eviction-protected; let them settle.
     await vi.runAllTimersAsync()
+    vi.advanceTimersByTime(TTL + 1)
 
     for (let i = 0; i < 900; i++) {
       engine.setReactions(`filler${i}`, [{ key: '+1', count: 1, reacted: false }])
+      if (i % 100 === 0) vi.advanceTimersByTime(TTL + 1)
     }
 
     expect(engine.reactionsByEntity.size).toBeLessThanOrEqual(MAX)

--- a/src/stores/shared/messageCacheUtils.ts
+++ b/src/stores/shared/messageCacheUtils.ts
@@ -9,6 +9,7 @@ import { debug } from '@/utils/debug'
 export interface MessageCacheEntry {
   messages: Message[]
   lastFetchedAt: Date
+  oldestMessageId: string | null
   allMessagesLoaded: boolean
   lastModified?: Date
 }
@@ -20,13 +21,20 @@ export const MAX_CACHED_MESSAGES = 200
 // Trims a backgrounded conversation to its newest MAX_CACHED_MESSAGES.
 // Arrays are created_at-ascending; the drop is from the front.
 // Not for the on-screen conversation: the store renders this array.
+//
+// Dropping messages reopens pagination: allMessagesLoaded is restored
+// verbatim on cache re-entry and gates the scroll-up sentinel, so leaving it
+// set strands the trimmed history behind a closed gate. oldestMessageId
+// follows the new front of the array.
 export function trimCachedMessages(
-  cache: Map<string, Pick<MessageCacheEntry, 'messages'>>,
+  cache: Map<string, Pick<MessageCacheEntry, 'messages' | 'allMessagesLoaded' | 'oldestMessageId'>>,
   conversationId: string | null | undefined
 ): void {
   const entry = conversationId ? cache.get(conversationId) : undefined
   if (!entry || entry.messages.length <= MAX_CACHED_MESSAGES) return
   entry.messages.splice(0, entry.messages.length - MAX_CACHED_MESSAGES)
+  entry.allMessagesLoaded = false
+  entry.oldestMessageId = entry.messages[0]?.id ?? null
 }
 
 // Sorted insert by created_at. Realtime messages are usually newest, so

--- a/src/stores/shared/reactionEngine.ts
+++ b/src/stores/shared/reactionEngine.ts
@@ -134,16 +134,24 @@ export function createReactionEngine<G, E>(
 
   // Bound memory in long sessions: past this many cached entities, drop the
   // least-recently-fetched ones (they refetch on next view anyway).
+  //
+  // Entries fetched within cacheTtlMs are the working set - viewport plus
+  // recent scrollback. Evicting those costs a get_reactions RPC per
+  // reaction_event per viewer, which applyRealtimeDelta exists to avoid, so
+  // the cap yields to the TTL and the map may sit above MAX_CACHED_ENTITIES
+  // until the working set ages out.
   const MAX_CACHED_ENTITIES = 500
   function evictStaleEntries(): void {
     if (reactionsByEntity.size <= MAX_CACHED_ENTITIES) return
+    const now = Date.now()
     const byAge = [...lastFetched.entries()].sort((a, b) => a[1] - b[1])
     const toEvict = reactionsByEntity.size - MAX_CACHED_ENTITIES
     let evicted = 0
-    for (const [id] of byAge) {
+    for (const [id, fetchedAt] of byAge) {
       if (evicted >= toEvict) break
-      // A reconcile in flight writes back; skip those. Settled optimistic
-      // state is evictable and refetches on next view.
+      // Ascending by fetch time; everything past here is inside the TTL.
+      if (now - fetchedAt < cacheTtlMs) break
+      // A reconcile in flight writes back; skip those.
       if (pendingReconcileTimeouts.has(id)) continue
       reactionsByEntity.delete(id)
       optimisticByEntity.delete(id)

--- a/src/stores/useChat.ts
+++ b/src/stores/useChat.ts
@@ -182,6 +182,12 @@ export const useChatStore = defineStore('chat', {
       evictOldestCacheEntry(this.messageCache, this.maxCacheSize);
     },
 
+    // Channel -> DM leaves the channel without calling fetchMessages, so the
+    // trim at the top of fetchMessages never runs for that transition.
+    trimCachedChannel() {
+      trimCachedMessages(this.messageCache, this.currentChannelId);
+    },
+
     async fetchMessages(channelId: string, oldestMessageId: string = '', signal?: AbortSignal) {
       if (this.loadingOlderMessages && oldestMessageId !== '') return;
 

--- a/src/stores/useDM.ts
+++ b/src/stores/useDM.ts
@@ -329,8 +329,7 @@ export const useDMStore = defineStore('dm', () => {
 
   let _userUpdatedHandler: ((event: any) => void) | null = null
   let _userDataServiceRef: any = null
-  // Held so cleanup() can remove it: an inline arrow cannot be unregistered,
-  // and the closure pins the store's whole decryption path.
+  // Held so cleanup() can remove it; an inline arrow cannot be unregistered.
   let _keyReceivedHandler: ((e: Event) => void) | null = null
   const setupEncryptionKeyListener = () => {
     if (_keyReceivedHandler) return
@@ -1932,6 +1931,12 @@ export const useDMStore = defineStore('dm', () => {
     removeMessageFromCache(tempId);
   };
 
+  // DM -> channel leaves the conversation without calling
+  // setCurrentConversation, so the trim there never runs for that transition.
+  const trimCachedConversation = () => {
+    trimCachedMessages(messageCache.value, currentConversationId.value)
+  }
+
   const setCurrentConversation = (conversationId: string | null) => {
     const previousConversationId = currentConversationId.value
     debug.log('Setting current conversation:', {
@@ -2062,9 +2067,8 @@ export const useDMStore = defineStore('dm', () => {
           }
         }
       }
-      // Re-entrant: this runs again on every DM conversation switch. Drop the
-      // previous registration before overwriting the slot, or it becomes
-      // unreachable for cleanup() and leaks a closure over `conversations`.
+      // Re-entrant: runs again on every conversation switch. Drop the previous
+      // registration before overwriting the slot, or cleanup() cannot reach it.
       if (_userUpdatedHandler && _userDataServiceRef) {
         _userDataServiceRef.removeEventListener('user-updated', _userUpdatedHandler)
       }
@@ -2083,13 +2087,9 @@ export const useDMStore = defineStore('dm', () => {
   }
 
   // Pulls anything newer than the newest message held for `conversationId`.
-  //
-  // The open thread is fed by `dm-conversation-{id}` postgres_changes, which can
-  // stop delivering while still reporting SUBSCRIBED; the health check only
-  // catches a globally dead socket, and silence is indistinguishable from a
-  // quiet conversation. `user:{profileId}` broadcast keeps working in that
-  // state, so an `unread:change` for the open conversation is a reliable signal
-  // that the thread channel missed something.
+  // `dm-conversation-{id}` postgres_changes can stop delivering while still
+  // reporting SUBSCRIBED; `user:{profileId}` broadcast keeps working, so an
+  // `unread:change` for the open conversation signals a missed row.
   let _reconcileInFlight: string | null = null
   const reconcileConversationMessages = async (conversationId: string): Promise<number> => {
     if (!conversationId || _reconcileInFlight === conversationId) return 0
@@ -2441,9 +2441,8 @@ export const useDMStore = defineStore('dm', () => {
       conv.unread_count = unread
       conv.last_activity = new Date().toISOString()
 
-      // This broadcast rides a different channel from the open thread's
-      // postgres_changes stream, so it still arrives when that stream has gone
-      // quiet without reporting an error. Reconcile rather than trust it.
+      // Separate channel from the thread's postgres_changes stream; arrives
+      // when that stream is silent. Reconcile rather than trust it.
       if (conversationId === currentConversationId.value) {
         void reconcileConversationMessages(conversationId)
       }
@@ -2478,8 +2477,7 @@ export const useDMStore = defineStore('dm', () => {
     }
 
     // Logout only. cleanup(false) keeps messageCache warm across a layout
-    // unmount; unbinding there would leave those cached rows undecrypted when
-    // a key arrives from the standalone /settings route.
+    // unmount, and those rows still need a key arriving from /settings.
     if (resetData && _keyReceivedHandler) {
       window.removeEventListener('megolm-key-received', _keyReceivedHandler)
       _keyReceivedHandler = null
@@ -3122,6 +3120,7 @@ export const useDMStore = defineStore('dm', () => {
     retryDMMessage,
     discardFailedDMMessage,
     setCurrentConversation,
+    trimCachedConversation,
     switchToConversation,
     clearDMMessages,
     setupConversationSubscription,

--- a/src/views/ChatView.vue
+++ b/src/views/ChatView.vue
@@ -83,6 +83,7 @@ const loadMessages = async () => {
   if (props.isDM) {
     // Clean up channel subscriptions when entering DM view to prevent leaks
     chatStore.unsubscribeFromMessages()
+    chatStore.trimCachedChannel()
 
     const conversationId = route.params.conversationId as string
     if (conversationId) {
@@ -139,6 +140,7 @@ const loadMessages = async () => {
     }
 
     if (serverId && channelId) {
+      dmStore.trimCachedConversation()
       if (serverChannelStore.currentChannelId !== channelId) {
         serverChannelStore.setCurrentChannel(channelId)
       }


### PR DESCRIPTION
Follow-up to #69. Three defects found reviewing that change, plus a comment pass.

### `trimCachedMessages` stranded history behind a closed gate
The trim dropped messages but left `allMessagesLoaded` set. That flag is restored verbatim on cache re-entry and gates the scroll-up sentinel, so a conversation scrolled to its start and revisited inside the cache TTL rendered 200 messages with the rest unreachable — no scroll-up, recovering only when the entry expired. It now clears the flag and moves `oldestMessageId` to the new front.

### Reaction eviction reinstated the herd it was built to avoid
Eviction ran strictly by age and reached entries still on screen. `CoreMessageService` calls `bulkSet` per message page, so a working set above 500 evicted live entries, and each subsequent `reaction_event` on them cost a full `get_reactions` RPC **per viewer** — exactly what `applyRealtimeDelta` exists to prevent. Eviction now stops at the `cacheTtlMs` boundary; the map may sit above the cap until the working set ages out. That trade is deliberate: correctness and request volume over a hard ceiling.

### The trim never ran across the channel↔DM boundary
Channel→DM never calls `fetchMessages`; DM→channel never calls `setCurrentConversation`. Only channel→channel and DM→DM were bounded. Both transitions now trim explicitly, without touching subscriptions.

### Comments
Cut back to stated facts — retained counts, page sizes, array ordering, misuse guards. Bug narratives removed.

## Verification
`vue-tsc` exit 0 · 697 tests (49 files) · `npm run build` clean.

New tests fail on the pre-fix code for the right reason, confirmed by reverting each fix in place:
- `expected true to be false` (allMessagesLoaded)
- `expected 'm0' to be 'm800'` (oldestMessageId)

The reaction tests were rewritten rather than kept passing: the TTL guard intentionally changes the invariant, so the old assertions encoded behaviour that is no longer correct. Two new tests pin the new one — fresh entries survive past the cap, and eviction resumes once they age out.