### PR TITLE
fix(federation): stop a reaction boomeranging into a second chip

### DIFF
--- a/federation-backend/src/activitypub/ActivityProcessor.ts
+++ b/federation-backend/src/activitypub/ActivityProcessor.ts
@@ -16,6 +16,7 @@ import config from '../config/index.js';
 import { harmonyVoiceMessageFromObject } from '../utils/voiceMessageFederation.js';
 import { safeFetch } from '../utils/ssrfProtection.js';
 import { pgrstOrValue } from '../utils/postgrestFilter.js';
+import { stripOwnEmojiDomain } from '../utils/emojiResolvers.js';
 
 /**
  * Extract message UUID from a URL like https://domain/messages/{uuid}
@@ -1408,6 +1409,9 @@ export class ActivityProcessor {
       if (!emoji || normalizedEmoji === '❤' || normalizedEmoji === '❤️') {
         normalizedEmoji = '❤️';
       }
+      // A reaction emitted here returns qualified with our own domain, which the duplicate
+      // check below compares literally against the `:name:` already stored.
+      normalizedEmoji = stripOwnEmojiDomain(normalizedEmoji) ?? normalizedEmoji;
       
       logger.info(`Inserting reaction: emoji_id=${emojiId}, custom_content=${normalizedEmoji}`);
       

--- a/federation-backend/src/activitypub/ActorService.ts
+++ b/federation-backend/src/activitypub/ActorService.ts
@@ -4,6 +4,7 @@ import { asyncHandler } from '../middleware/errorHandler.js';
 import { profileToActor } from './converters/toActivityPub.js';
 import { actorToProfile, noteToContent } from './converters/fromActivityPub.js';
 import { resolveLocalProfileEmojis } from './emojiResolver.js';
+import { stripOwnEmojiDomain } from '../utils/emojiResolvers.js';
 import { ActivityProcessor } from './ActivityProcessor.js';
 import { SignatureService } from './SignatureService.js';
 import { logger } from '../utils/logger.js';
@@ -1534,7 +1535,11 @@ async function _fetchRemotePostReactionsImpl(
         // emits no index predicate, so ON CONFLICT infers no arbiter. Mirrors
         // ActivityProcessor.processLike.
         if (postId && localProfile?.id) {
-          const content = reactionContent || emoji;
+          // A reaction this instance emitted returns qualified with our own domain, as
+          // `:name@our.domain:` against the `:name:` already stored. The dedupe below
+          // compares the shortcode literally, so the two spellings both persist and the
+          // chip splits. Strip the suffix when the domain is ours.
+          const content = stripOwnEmojiDomain(reactionContent || emoji);
 
           const { data: existing } = await supabase
             .from('post_interactions')

--- a/federation-backend/src/utils/__tests__/stripOwnEmojiDomain.test.ts
+++ b/federation-backend/src/utils/__tests__/stripOwnEmojiDomain.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('../../config/index.js', () => ({
+  default: { INSTANCE_DOMAIN: 'har.mony.lol' },
+}))
+vi.mock('../../config/supabase.js', () => ({ getSupabaseClient: () => ({}) }))
+
+const { stripOwnEmojiDomain } = await import('../emojiResolvers.js')
+
+// A reaction this instance emitted federates out and returns qualified with our own domain.
+// The ingest dedupe compares the shortcode literally, so `:vibingcat@har.mony.lol:` alongside
+// the stored `:vibingcat:` persisted both and split the chip.
+describe('stripOwnEmojiDomain', () => {
+  it('strips this instance from a qualified shortcode', () => {
+    expect(stripOwnEmojiDomain(':vibingcat@har.mony.lol:')).toBe(':vibingcat:')
+  })
+
+  it('is case-insensitive on the domain', () => {
+    expect(stripOwnEmojiDomain(':vibingcat@HAR.MONY.LOL:')).toBe(':vibingcat:')
+  })
+
+  it('leaves another instance qualified, since that emoji is genuinely theirs', () => {
+    expect(stripOwnEmojiDomain(':vibingcat@spacify.cloud:')).toBe(':vibingcat@spacify.cloud:')
+  })
+
+  it('passes through an unqualified shortcode and a unicode char', () => {
+    expect(stripOwnEmojiDomain(':vibingcat:')).toBe(':vibingcat:')
+    expect(stripOwnEmojiDomain('🔥')).toBe('🔥')
+  })
+
+  it('passes through null and empty', () => {
+    expect(stripOwnEmojiDomain(null)).toBeNull()
+    expect(stripOwnEmojiDomain('')).toBe('')
+  })
+})

--- a/federation-backend/src/utils/emojiResolvers.ts
+++ b/federation-backend/src/utils/emojiResolvers.ts
@@ -11,6 +11,18 @@ import config from '../config/index.js';
 import { getFullEmojiUrl } from './urlUtils.js';
 import { logger } from './logger.js';
 
+/**
+ * `:name@domain:` -> `:name:` when the domain is this instance. Remote instances qualify a
+ * shortcode with the emoji's origin, so a reaction emitted here returns qualified with our
+ * own domain and no longer matches the row already stored.
+ */
+export function stripOwnEmojiDomain(shortcode: string | null | undefined): string | null {
+  if (!shortcode) return shortcode ?? null;
+  const m = /^:([^:@\s]+)@([^:\s]+):$/.exec(shortcode);
+  if (!m) return shortcode;
+  return m[2].toLowerCase() === config.INSTANCE_DOMAIN.toLowerCase() ? `:${m[1]}:` : shortcode;
+}
+
 export interface ResolvedEmoji {
   /** The string to put in `content` / `_misskey_reaction` - either a unicode
    *  character (e.g. "😇") or a shortcode (e.g. ":blobcat:"). */


### PR DESCRIPTION
A reaction emitted here federates out and returns qualified with our own domain:
`:vibingcat@har.mony.lol:` against the `:vibingcat:` already stored. The ingest dedupe compares
the shortcode literally, so both rows persisted and the chip split.

Observed on production, a post from spacify.cloud viewed on har.mony.lol:

```
emoji_id=63ab5f1e  :vibingcat:               federated=f  y4my4m  is_local=t
emoji_id=NULL      :vibingcat@har.mony.lol:  federated=t  y4my4m  is_local=t
```

A local user with a federated interaction row. The two land in different partial unique
indexes -- `idx_post_interactions_unique_emoji_by_id` covers one and
`..._unique_emoji_by_content` the other -- so neither blocks the other.

`stripOwnEmojiDomain` reduces `:name@domain:` to `:name:` when the domain is this instance,
applied at both ingest paths before their dedupe check. Another instance's domain is left
alone, since that emoji genuinely is theirs.

Fixes new reactions only. The rows already stored still render split; merging those needs the
FK-safe repair pass, which is separate.